### PR TITLE
 Fix bug in RestoUser::signLicense 

### DIFF
--- a/include/resto/RestoUser.php
+++ b/include/resto/RestoUser.php
@@ -343,6 +343,10 @@ class RestoUser{
      *  @param RestoLicense $license
      */
     public function signLicense($license) {
+        /*
+         * Get array which describe the license
+         */
+        $license = $license->toArray();
         
         /*
          * User can sign license if it does not reach the signature quota


### PR DESCRIPTION
cannot use RestoLicense as array, call RestoLicense::toArray before doing it