### PR TITLE
deploy.sh $TARGETDIR and $TARGETDIR variables double quoted

### DIFF
--- a/_install/deploy.sh
+++ b/_install/deploy.sh
@@ -44,8 +44,8 @@ if [ -d "$TARGETDIR" ]; then
     fi
 fi
 
-mkdir $TARGETDIR
+mkdir "$TARGETDIR"
 echo " ==> Copy files to $TARGETDIR directory"
-cp -Rf $SRCDIR/.htaccess $SRCDIR/favicon.ico $SRCDIR/index.php $SRCDIR/include $SRCDIR/lib $TARGETDIR
-echo " ==> Successfully install resto to $TARGETDIR directory"
+cp -t "$TARGETDIR" -Rf "$SRCDIR/.htaccess" "$SRCDIR/favicon.ico" "$SRCDIR/index.php" "$SRCDIR/include" "$SRCDIR/lib"
+echo " ==> Successfully installed resto to $TARGETDIR directory"
 echo " ==> Now, do not forget to check $TARGETDIR/include/config.php configuration !"


### PR DESCRIPTION
double quotes added in case of someone used in source/target path spaces or other special characters