### PR TITLE
Hide PHP warnings when postgres connection failed

### DIFF
--- a/include/resto/Drivers/RestoDatabaseDriver_PostgreSQL.php
+++ b/include/resto/Drivers/RestoDatabaseDriver_PostgreSQL.php
@@ -670,7 +670,7 @@ class RestoDatabaseDriver_PostgreSQL extends RestoDatabaseDriver {
                     $dbInfo[] = 'host=' . $options['host'];
                     $dbInfo[] = 'port=' . (isset($options['port']) ? $options['port'] : '5432');
                 }
-                $dbh = pg_connect(join(' ', $dbInfo));
+                $dbh = @pg_connect(join(' ', $dbInfo));
                 if (!$dbh) {
                     throw new Exception();
                 }

--- a/include/resto/Resto.php
+++ b/include/resto/Resto.php
@@ -262,7 +262,7 @@ class Resto {
             /*
              * Stream data unless HTTP HEAD is requested
              */
-            if ($this->context->method !== 'HEAD') {
+            if ($this->context == null || $this->context->method !== 'HEAD') {
                 echo $response;
             }
             


### PR DESCRIPTION
Hide PHP warnings when postgres connection failed
include/resto/Drivers/RestoDatabaseDriver_PostgreSQL.php is changed only in line 673 (@ added) but it has cr+lf line endings while rest of code have lf so fixed it to