### PR TITLE
estimated totalResults count on empty result set bugfix

### DIFF
--- a/include/resto/RestoFeatureCollection.php
+++ b/include/resto/RestoFeatureCollection.php
@@ -480,7 +480,19 @@ class RestoFeatureCollection {
      * @param integer $offset
      */
     private function getPaging($count, $limit, $offset) {
+        /*
+         * If first page contains no features count must be 0 not estimated value
+         */
+        if ($offset == 0 && count($this->restoFeatures) == 0){
+            $count = array(
+                'total' => 0,
+                'isExact' => true
+            );
+        }
 
+        /*
+         * Default paging
+         */
         $paging = array(
             'count' => $count,
             'startPage' => 1,
@@ -507,6 +519,7 @@ class RestoFeatureCollection {
                 'totalPage' => $totalPage
             );
         }
+
         return $paging;
     }
 


### PR DESCRIPTION
Now if user give some nonsense criteria like e.g:
http://resto.mapshup.com/2.2/api/collections/search.json?platform=LANDSAT8&cloudCover=100

He recive empty feature collection with totalResults containing estimated count not zero like he should
