### PR TITLE
New Feature: Search result sorting

### DIFF
--- a/include/resto/Drivers/PostgreSQL/Functions_filters.php
+++ b/include/resto/Drivers/PostgreSQL/Functions_filters.php
@@ -30,7 +30,9 @@ class Functions_filters {
         'language',
         'geo:name',
         'geo:lat', // linked to geo:lon
-        'geo:radius' // linked to geo:lon
+        'geo:radius', // linked to geo:lon
+        'resto:sortParam',
+        'resto:sortOrder'
     );
     
     /**
@@ -651,5 +653,4 @@ class Functions_filters {
         }
         return $typeAndValue;
     }
-   
 }

--- a/include/resto/Drivers/RestoDatabaseDriver_PostgreSQL.php
+++ b/include/resto/Drivers/RestoDatabaseDriver_PostgreSQL.php
@@ -33,12 +33,12 @@ require 'PostgreSQL/Functions_history.php';
  * RESTo PostgreSQL Database
  */
 class RestoDatabaseDriver_PostgreSQL extends RestoDatabaseDriver {
-    
+
     /*
      * Facet Util reference
      */
     public $facetUtil;
-    
+
     /**
      * Constructor
      * 
@@ -47,19 +47,13 @@ class RestoDatabaseDriver_PostgreSQL extends RestoDatabaseDriver {
      * @throws Exception
      */
     public function __construct($config, $cache) {
-        
         parent::__construct($config, $cache);
         
         $this->dbh = $this->getHandler($config);
         
         $this->facetUtil = new RestoFacetUtil();
-        
-        if (isset($config['resultsPerPage'])) {
-            $this->resultsPerPage = $config['resultsPerPage'];
-        }
-        
     }
-    
+
     /**
      * Get object by typename
      * 
@@ -688,5 +682,4 @@ class RestoDatabaseDriver_PostgreSQL extends RestoDatabaseDriver {
         
         return $dbh;
     }
-    
 }

--- a/include/resto/RestoDatabaseDriver.php
+++ b/include/resto/RestoDatabaseDriver.php
@@ -64,27 +64,32 @@ abstract class RestoDatabaseDriver {
     const WHERE_CLAUSE = 39;
     const COUNT_ESTIMATE = 40;
     const AREA = 41;
-    
+
     /*
      * Results per page
      */
     public $resultsPerPage = 20;
 
     /*
+     * Allowed sort parameters
+     */
+    public $sortParams = array('startdate');
+
+    /*
      * Cache object
      */
     public $cache = null;
-    
+
     /*
      * Database handler
      */
     public $dbh;
-    
+
     /*
      * Database username
      */
     public $dbUsername = 'resto';
-    
+
     /**
      * Constructor
      * 
@@ -94,8 +99,15 @@ abstract class RestoDatabaseDriver {
      */
     public function __construct($config, $cache) {
         $this->cache = isset($cache) ? $cache : new RestoCache(null);
+
+        if (isset($config['resultsPerPage'])) {
+            $this->resultsPerPage = $config['resultsPerPage'];
+        }
+        if (isset($config['sortParams']) && is_array($config['sortParams'])) {
+            $this->sortParams = $config['sortParams'];
+        }
     } 
-    
+
     /**
      * List object by type name
      * 
@@ -103,7 +115,7 @@ abstract class RestoDatabaseDriver {
      * @throws Exception
      */
     abstract public function get($typeName);
-    
+
     /**
      * Check if $typeName constraint is true
      * 

--- a/include/resto/RestoModel.php
+++ b/include/resto/RestoModel.php
@@ -889,7 +889,39 @@ abstract class RestoModel {
             'title' => 'Product publication within search engine before specified date and time',
             'operation' => '<=',
             'pattern' => '^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(|Z|[\+\-][0-9]{2}:[0-9]{2}))?$'
-        )
+        ),
+        /**
+         *  @SWG\Parameter(
+         *      name="sortParam",
+         *      in="query",
+         *      description="Sort results by parameter",
+         *      required=false,
+         *      type="string",
+         *      pattern="^[a-zA-Z0-9]{4,}$",
+         *      default="startDate"
+         *  )
+         */
+        'resto:sortParam' => array(
+            'osKey' => 'sortParam',
+            'pattern' => '^[a-zA-Z0-9]{4,}$',
+            'title' => 'Sort results by parameter (default: startDate)'
+        ),
+        /**
+         *  @SWG\Parameter(
+         *      name="sortOrder",
+         *      in="query",
+         *      description="Sorting order (ascending or descending)",
+         *      required=false,
+         *      type="string",
+         *      pattern="^(asc|desc|ascending|descending)$",
+         *      default="descending"
+         *  )
+         */
+        'resto:sortOrder' => array(
+            'osKey' => 'sortOrder',
+            'pattern' => '^(asc|desc|ascending|descending)$',
+            'title' => 'Sorting order (ascending or descending)',
+        ),
     );
 
     public $extendedProperties = array();
@@ -1146,7 +1178,5 @@ abstract class RestoModel {
         }
             
         return true;
-        
     }
-    
 }


### PR DESCRIPTION
In resto config sorting on selected columns can be enabled
to enable sorting by cloudcover set in ```database``` section:
```'sortParams' => array('startdate', 'cloudcover')```
And then using ```sortParam``` & ```sortOrder``` search result can be sorted
If column not listed in config is used, default sorting by ```startdate``` is used

If not explicitly enabled in config file, search result sorting is not supported and default sorting is always used