### PR TITLE
Add new deployment variables

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -40,7 +40,7 @@ A normal PG user with `create schema` and `insert on spatial_ref_sys` rights is 
         grant create on database <dbname> to <dbuser>;
         grant insert on table spatial_ref_sys to <dbuser>;
 
-resto tables, functions and triggers will be installed in a `resto` schema by running [scripts/installOnExternalDB.sh](https://github.com/jjrom/resto/blob/master/scripts/installOnExternalDB.sh):
+By default, resto tables, functions and triggers will be installed in a `resto` schema by running [scripts/installOnExternalDB.sh](https://github.com/jjrom/resto/blob/master/scripts/installOnExternalDB.sh). The default schema can be changed by setting the DATABASE_SCHEMA environment variable in config.env
 
         ./scripts/installOnExternalDB.sh -e <config file>
         

--- a/app/resto/core/RestoDatabaseDriver.php
+++ b/app/resto/core/RestoDatabaseDriver.php
@@ -27,6 +27,11 @@ class RestoDatabaseDriver
     public $schema = 'resto';
 
     /*
+     * Use geometry_part joined table for geometrical intersection
+     */
+    public $useGeometryPart = false;
+
+    /*
      * Results per page
      */
     public $resultsPerPage = 20;
@@ -66,6 +71,10 @@ class RestoDatabaseDriver
 
             if (isset($config['schema'])) {
                 $this->schema = $config['schema'];
+            }
+
+            if (isset($config['useGeometryPart'])) {
+                $this->useGeometryPart = filter_var($config['useGeometryPart'], FILTER_VALIDATE_BOOLEAN);
             }
 
             if (isset($config['resultsPerPage'])) {

--- a/app/resto/core/RestoDatabaseDriver.php
+++ b/app/resto/core/RestoDatabaseDriver.php
@@ -74,7 +74,7 @@ class RestoDatabaseDriver
             }
 
             if (isset($config['useGeometryPart'])) {
-                $this->useGeometryPart = filter_var($config['useGeometryPart'], FILTER_VALIDATE_BOOLEAN);
+                $this->useGeometryPart = $config['useGeometryPart'];
             }
 
             if (isset($config['resultsPerPage'])) {

--- a/app/resto/core/RestoModel.php
+++ b/app/resto/core/RestoModel.php
@@ -306,12 +306,10 @@ abstract class RestoModel
      * Parameters to apply to database storage for products related to this model
      * 
      *  - tablePrefix : all features belonging to a collection referencing this model will be stored in a dedicated table [tablePrefix]__feature instead of feature"
-     *  - useGeometryPart : if true, geometry searches are processed using geometry_part table instead of feature table
      *  - storeFacets = if true, facets are stored for model related products
      */
     public $dbParams = array(
         'tablePrefix' => '',
-        'useGeometryPart' => false,
         'storeFacets' => true
     );
 

--- a/app/resto/core/dbfunctions/FiltersFunctions.php
+++ b/app/resto/core/dbfunctions/FiltersFunctions.php
@@ -676,16 +676,17 @@ class FiltersFunctions
 
     /**
      * 
-     * If $model->dbParams['useGeometryPart'] is true then geometry is indexed in schema.geometry_part joined table
+     * If $this->context->dbDriver->useGeometryPart is true then geometry is indexed in schema.geometry_part joined table
      * Otherwise is is directly retrieved from the indexed "feature_geometry" table 
      * This should be used for large geometry
+     * 
      * @param RestolModel $model
      */
     private function getGeometryTableName($model) {
 
         $tablePrefix = $this->context->dbDriver->schema . '.' . $model->dbParams['tablePrefix'];
        
-        if ($model->dbParams['useGeometryPart']) {
+        if ($this->context->dbDriver->useGeometryPart) {
             $this->joins[] = 'JOIN ' . $tablePrefix . 'geometry_part ON ' . $tablePrefix . 'feature.id=' . $tablePrefix . 'geometry_part.id';
             return $tablePrefix . 'geometry_part';
         }

--- a/build/resto-database/installDB.sh
+++ b/build/resto-database/installDB.sh
@@ -11,14 +11,25 @@ trap 'err_report $LINENO' ERR
 PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/00_resto_extensions.sql > /dev/null 2>&1
 PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/01_resto_functions.sql > /dev/null 2>&1
 PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/01_tamn.sql > /dev/null 2>&1
-PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/02_resto_model.sql > /dev/null 2>&1
-# [IMPORTANT] Deactivate geometry_part split - should be completely removed in next version ?
-#psql -X -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/03_resto_triggers.sql > /dev/null 2> errors.log
-PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/04_resto_inserts.sql > /dev/null 2>&1
-PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/05_resto_indexes.sql > /dev/null 2>&1
+
+if [[ "${DATABASE_SCHEMA}" == "" ]]; then
+    PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/02_resto_model.sql > /dev/null 2>&1
+    # [IMPORTANT] Deactivate geometry_part split - should be completely removed in next version ?
+    #psql -X -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/03_resto_triggers.sql > /dev/null 2> errors.log
+    PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/04_resto_inserts.sql > /dev/null 2>&1
+    PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f /sql/05_resto_indexes.sql > /dev/null 2>&1
+else
+    cat /sql/02_resto_model.sql | sed "s/CREATE SCHEMA IF NOT EXISTS resto/CREATE SCHEMA IF NOT EXISTS ${DATABASE_SCHEMA}/g" | sed "s/resto\./${DATABASE_SCHEMA}\./g" | PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+    cat /sql/04_resto_inserts.sql | sed "s/resto\./${DATABASE_SCHEMA}\./g" | PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+    cat /sql/05_resto_indexes.sql | sed "s/resto\./${DATABASE_SCHEMA}\./g" | PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+fi
 
 # Addons sql files
 for sql in $(find /sql/addons -name "*.sql" | sort); do
     echo "[PROCESS] " . $sql
-    PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f $sql > /dev/null 2>&1
+    if [[ "${DATABASE_SCHEMA}" == "" ]]; then
+        PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" -f $sql > /dev/null 2>&1
+    else
+        cat $sql | sed "s/resto\./${DATABASE_SCHEMA}\./g" | PGPASSWORD=${POSTGRES_PASSWORD} psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"> /dev/null 2>&1
+    fi
 done

--- a/build/resto-database/sql/03_resto_triggers.sql
+++ b/build/resto-database/sql/03_resto_triggers.sql
@@ -1,40 +1,36 @@
 --
--- resto geometry_part split
+-- Subdivide input geometry to geometry_part table
 --
-
--- 
--- On INSERT resto.feature THEN
---
---     1. Split resto.feature.geom into part
---     2. Store parts within resto.geometry_part
---
-CREATE OR REPLACE FUNCTION resto.store_geometry_part()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION resto.store_geometry_part(id UUID, collection TEXT, geom GEOMETRY)
+RETURNS VOID AS $$
 DECLARE
     geo_type TEXT;
 BEGIN
 
     -- Do nothing if geom is not set
-    IF NEW.geom IS NULL THEN
-        RETURN NEW;
+    IF geom IS NULL THEN
+        RETURN;
     END IF;
 
     -- First get geometry type
-    geo_type := GeometryType(NEW.geom);
+    geo_type := GeometryType(geom);
     
     -- Do not touch (MULTI)POINT
     IF geo_type = 'POINT' OR geo_type = 'MULTIPOINT' THEN
-        INSERT INTO resto.geometry_part (id, collection, part_num, geom) VALUES (NEW.id, NEW.collection, 1, NEW.geom);
+        INSERT INTO resto.geometry_part (id, collection, part_num, geom) VALUES (id, collection, 1, geom);
     ELSE
         INSERT INTO resto.geometry_part
-            SELECT NEW.id, NEW.collection, ordinality AS part_num, sub AS geom
-            FROM ST_SubDivide(NEW.geom, 32) WITH ordinality AS sub;
+            SELECT id, collection, ordinality AS part_num, sub AS geom
+            FROM ST_SubDivide(geom, 32) WITH ordinality AS sub;
     END IF;
 
-    RETURN NEW;
+    RETURN;
 
 END
 $$ LANGUAGE plpgsql;
 
+-- 
+-- On INSERT on resto.feature THEN subdivide the input feature geometry and store it in geometry_part table
+--
 DROP TRIGGER IF EXISTS update_geometry_part ON resto.feature;
-CREATE TRIGGER update_geometry_part AFTER INSERT ON resto.feature FOR EACH ROW EXECUTE PROCEDURE resto.store_geometry_part();
+CREATE TRIGGER update_geometry_part AFTER INSERT ON resto.feature FOR EACH ROW EXECUTE PROCEDURE resto.store_geometry_part(NEW.id, NEW.collection, NEW.geom);

--- a/build/resto-database/sql/03_resto_triggers.sql
+++ b/build/resto-database/sql/03_resto_triggers.sql
@@ -29,8 +29,15 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION resto.trigger_store_geometry_part()
+RETURNS TRIGGER AS $$
+BEGIN
+    RETURN resto.store_geometry_part(NEW.id, NEW.collection, NEW.geom);
+END
+$$ LANGUAGE plpgsql;
+
 -- 
 -- On INSERT on resto.feature THEN subdivide the input feature geometry and store it in geometry_part table
 --
 DROP TRIGGER IF EXISTS update_geometry_part ON resto.feature;
-CREATE TRIGGER update_geometry_part AFTER INSERT ON resto.feature FOR EACH ROW EXECUTE PROCEDURE resto.store_geometry_part(NEW.id, NEW.collection, NEW.geom);
+CREATE TRIGGER update_geometry_part AFTER INSERT ON resto.feature FOR EACH ROW EXECUTE PROCEDURE resto.trigger_store_geometry_part();

--- a/build/resto/config.php.template
+++ b/build/resto/config.php.template
@@ -26,6 +26,7 @@ return array(
         'port' => ${DATABASE_PORT:-5432},
         'resultsPerPage' => ${SEARCH_RESULTS_PER_PAGE:-20},
         'sortKeys' => array(${SEARCH_SORTABLE_FIELDS:-'startDate','created'}),
+        'useGeometryPart' => '${USE_GEOMETRY_PART:-false}',
         'user' => '${DATABASE_USER_NAME:-resto}',
         'password' => '${DATABASE_USER_PASSWORD:-resto}'
     ),

--- a/build/resto/config.php.template
+++ b/build/resto/config.php.template
@@ -26,7 +26,7 @@ return array(
         'port' => ${DATABASE_PORT:-5432},
         'resultsPerPage' => ${SEARCH_RESULTS_PER_PAGE:-20},
         'sortKeys' => array(${SEARCH_SORTABLE_FIELDS:-'startDate','created'}),
-        'useGeometryPart' => '${USE_GEOMETRY_PART:-false}',
+        'useGeometryPart' => ${USE_GEOMETRY_PART:-false},
         'user' => '${DATABASE_USER_NAME:-resto}',
         'password' => '${DATABASE_USER_PASSWORD:-resto}'
     ),

--- a/config.env
+++ b/config.env
@@ -67,6 +67,9 @@ DATABASE_USER_PASSWORD=resto
 ### [IMPORTANT] Do not modify the default value 'resto' unless you know what you are doing or it will break everything !!!
 #DATABASE_SCHEMA=resto
 
+### True to use geometry_part table instead of feature to compute geometrical intersection
+#USE_GEOMETRY_PART=false
+
 ### PostgreSQL PGDATA directory i.e. directory on host where the database files are stored.
 ### [IMPORTANT] 
 ###    - This value should is only used if DATABASE_HOST is set to "restodb" (i.e. for local database container)


### PR DESCRIPTION
Two new environments variable:

* DATABASE_SCHEMA to change the name of the schema where the tables are created (default resto). This allow multiple instances of resto on the same database
* USE_GEOMETRY_PART to use the geometry_part table for geometrical computation instead of feature table (default is false). This is an experimental feature - juste leave it to false ;)