### PR TITLE
Add _heatmapNoGeo query parameters

### DIFF
--- a/app/resto/core/addons/STAC.php
+++ b/app/resto/core/addons/STAC.php
@@ -626,6 +626,16 @@ class STAC extends RestoAddOn
 * _all: Return all properties (This is the default)
 * _simple: Return all fields except *keywords* property"
      *      ),
+     *      @OA\Parameter(
+     *          name="_heatmapNoGeo",
+     *          in="query",
+     *          style="form",
+     *          description="[EXTENSION][Heatmap] True to compute search result heatmap without taking account geographical filter",
+     *          required=false,
+     *          @OA\Schema(
+     *              type="boolean"
+     *          )
+     *      ),
      *      @OA\Response(
      *          response="200",
      *          description="Features collection",

--- a/app/resto/core/api/FeaturesAPI.php
+++ b/app/resto/core/api/FeaturesAPI.php
@@ -541,6 +541,16 @@ class FeaturesAPI
      *              type="string"
      *          )
      *      ),
+     *      @OA\Parameter(
+     *          name="_heatmapNoGeo",
+     *          in="query",
+     *          style="form",
+     *          description="[EXTENSION][Heatmap] True to compute search result heatmap without taking account geographical filter",
+     *          required=false,
+     *          @OA\Schema(
+     *              type="boolean"
+     *          )
+     *      ),
      *      @OA\Response(
      *          response="200",
      *          description="Features collection",


### PR DESCRIPTION
Use by Heatmap extension. Set to true to compute a heatmap from the search result without taking account geographical filter (default is to use geographical filters)