### PR TITLE
[BREAKING CHANGE] Upgrade resto-database to postgis/postgis:14-master

### DIFF
--- a/app/resto/core/Resto.php
+++ b/app/resto/core/Resto.php
@@ -136,7 +136,7 @@ class Resto
     );
 
     // resto version
-    const VERSION = '6.1.7';
+    const VERSION = '6.1.8';
 
     /* ============================================================
      *              NEVER EVER TOUCH THESE VALUES

--- a/build/resto-database/Dockerfile
+++ b/build/resto-database/Dockerfile
@@ -8,8 +8,7 @@ ENV BUILD_DIR=./build/resto-database \
 # Add S6 supervisor (for graceful stop)
 RUN apt-get update \
     && apt-get install -y curl tzdata \
-    && curl -k -L -s https://github.com/just-containers/s6-overlay/releases/download/v${JUST_CONTAINERS_VERSION}/s6-overlay-${ARCH}.tar.gz | tar xvzf - -C / && \
-    && tar -xzf s6-overlay-${ARCH}.tar.gz -C / \
+    && curl -k -L -s https://github.com/just-containers/s6-overlay/releases/download/v${JUST_CONTAINERS_VERSION}/s6-overlay-${ARCH}.tar.gz | tar xvzf - -C / \
     && rm -rf s6-overlay-amd64.tar.gz \
     && apt-get clean \
     && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*

--- a/build/resto-database/Dockerfile
+++ b/build/resto-database/Dockerfile
@@ -2,16 +2,11 @@ FROM postgis/postgis:14-master
 LABEL maintainer="jerome.gasperi@gmail.com"
 
 ENV BUILD_DIR=./build/resto-database \
-    JUST_CONTAINERS_VERSION=1.22.1.0 \
-    ARCH=amd64
+    S6_OVERLAY_VERSION=1.22.1.0
 
 # Add S6 supervisor (for graceful stop)
-RUN apt-get update \
-    && apt-get install -y curl tzdata \
-    && curl -k -L -s https://github.com/just-containers/s6-overlay/releases/download/v${JUST_CONTAINERS_VERSION}/s6-overlay-${ARCH}.tar.gz | tar xvzf - -C / \
-    && rm -rf s6-overlay-amd64.tar.gz \
-    && apt-get clean \
-    && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz /tmp
+RUN tar -C / -xzf /tmp/s6-overlay-amd64.tar.gz
 ENTRYPOINT [ "/init" ]
 
 # Copy run.d configuration

--- a/build/resto-database/Dockerfile
+++ b/build/resto-database/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:13-3.1-alpine
+FROM postgis/postgis:14-master
 LABEL maintainer="jerome.gasperi@gmail.com"
 
 ENV BUILD_DIR=./build/resto-database \
@@ -6,9 +6,13 @@ ENV BUILD_DIR=./build/resto-database \
     ARCH=amd64
 
 # Add S6 supervisor (for graceful stop)
-RUN apk add --no-cache curl && \
-    curl -L -s https://github.com/just-containers/s6-overlay/releases/download/v${JUST_CONTAINERS_VERSION}/s6-overlay-${ARCH}.tar.gz | tar xvzf - -C / && \
-    apk del --no-cache curl
+RUN apt-get update \
+    && apt-get install -y curl tzdata \
+    && curl -k -L -s https://github.com/just-containers/s6-overlay/releases/download/v${JUST_CONTAINERS_VERSION}/s6-overlay-${ARCH}.tar.gz | tar xvzf - -C / && \
+    && tar -xzf s6-overlay-${ARCH}.tar.gz -C / \
+    && rm -rf s6-overlay-amd64.tar.gz \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 ENTRYPOINT [ "/init" ]
 
 # Copy run.d configuration


### PR DESCRIPTION
[WARNING] Upgrading jjrom/resto-database to postgis/postgis:14-master will break existing resto-database.
To upgrade, you need to :

* dump existing database with pg_dump
* deploy a fresh jjrom/resto-database (i.e. removing old previous database volume)
* restore the dump on the new database