### PR TITLE
Use input feature id directly if already a valid UUID - correct issue…

### DIFF
--- a/app/resto/core/RestoModel.php
+++ b/app/resto/core/RestoModel.php
@@ -813,7 +813,12 @@ abstract class RestoModel
 
         $productIdentifier = $data['id'] ?? $data['properties']['productIdentifier'] ?? null;
         $data['properties']['productIdentifier'] = $productIdentifier;
-        $featureId = isset($productIdentifier) ? RestoUtil::toUUID($productIdentifier) : RestoUtil::toUUID(md5(microtime().rand()));
+
+        /*
+         * [WARNING] New in resto 7.x - if input id / productIdentifier is already a valid UUID use it directly
+         * Correct issue #342 to be STAC compatible
+         */
+        $featureId = isset($productIdentifier) ? (RestoUtil::isValidUUID($productIdentifier)? $productIdentifier : RestoUtil::toUUID($productIdentifier) )  : RestoUtil::toUUID(md5(microtime().rand()));
 
         /*
          * First check if feature is already in database


### PR DESCRIPTION
[WARNING] Potential breaking change 

Previously, when posting a feature, resto generated a UUID from the input feature id as the new feature id.
Now, resto will only generate a UUID v5 from the input id if the input id is not already a valid UUID. In the latter case, the id is left untouched.
 
This correct issue #342