### PR TITLE
Add MERGE_ROOT_CATALOG_LINKS option to display "catalogs" and "facets…

### DIFF
--- a/app/resto/core/RestoUser.php
+++ b/app/resto/core/RestoUser.php
@@ -394,7 +394,7 @@ class RestoUser
     public function getGroups()
     {
         if ( !isset($this->groups) ) {
-            return (new GroupsFunctions($this->context->dbDriver))->getGroups(array('userid' => $this->profile['id']));
+            $this->groups = (new GroupsFunctions($this->context->dbDriver))->getGroups(array('userid' => $this->profile['id']));
         }
         return $this->groups;
     }   
@@ -414,7 +414,9 @@ class RestoUser
         ];
 
         for ($i = 0, $ii = count($groups); $i < $ii; $i++) {
-            $ids[] = $groups[$i]['id'];
+            if ( $groups[$i]['id'] !== RestoConstants::GROUP_DEFAULT_ID ) {
+                $ids[] = $groups[$i]['id'];
+            }
         }
 
         return $ids;

--- a/app/resto/core/addons/STAC.php
+++ b/app/resto/core/addons/STAC.php
@@ -1302,11 +1302,16 @@ class STAC extends RestoAddOn
             
             // Add parent link
             if ($nbOfSegments > 1) {
-                $this->links[] = array(
-                    'rel' => 'parent',
-                    'type' => RestoUtil::$contentTypes['json'],
-                    'href' => $this->context->core['baseUrl'] . '/catalogs/' . join('/', array_slice(array_map('rawurlencode', $this->segments), 0, -1))
-                );
+
+                // Parent is root in this case
+                if ( ! ($this->context->core['mergeRootCatalogLinks'] && $nbOfSegments === 2) ) {
+                    $this->links[] = array(
+                        'rel' => 'parent',
+                        'type' => RestoUtil::$contentTypes['json'],
+                        'href' => $this->context->core['baseUrl'] . '/catalogs/' . join('/', array_slice(array_map('rawurlencode', $this->segments), 0, -1))
+                    );
+                } 
+                
             }
             
             $searchIsSet = false;

--- a/config-dev.env
+++ b/config-dev.env
@@ -94,7 +94,7 @@ JWT_PASSPHRASE="Super secret passphrase"
 
 ### True to display "catalogs" and "facets" childs directly within the STAC root endpoint
 ### instead of having them under respectively "catalogs" and "facets" parents
-#MERGE_ROOT_CATALOG_LINKS=true
+#MERGE_ROOT_CATALOG_LINKS=false
 
 ### Automatic user validation on activation
 #USER_AUTOVALIDATION=true

--- a/config.env
+++ b/config.env
@@ -98,7 +98,7 @@ JWT_PASSPHRASE="Super secret passphrase"
 
 ### True to display "catalogs" and "facets" childs directly within the STAC root endpoint
 ### instead of having them under respectively "catalogs" and "facets" parents
-#MERGE_ROOT_CATALOG_LINKS=true
+#MERGE_ROOT_CATALOG_LINKS=false
 
 ### Automatic user validation on activation
 #USER_AUTOVALIDATION=true


### PR DESCRIPTION
…" childs directly within the STAC root endpoint instead of having them under respectively "catalogs" and "facets" parents