### PR TITLE
Bunch of update (see description)

### DIFF
--- a/admin_scripts/migrate_to_9.5.9.php
+++ b/admin_scripts/migrate_to_9.5.9.php
@@ -1,0 +1,33 @@
+#!/command/with-contenv php
+
+<?php
+
+    require_once("/app/resto/core/RestoConstants.php");
+    require_once("/app/resto/core/RestoDatabaseDriver.php");
+    require_once("/app/resto/core/utils/RestoLogUtil.php");
+    require_once("/app/resto/core/utils/Antimeridian.php");
+    require_once("/app/resto/core/dbfunctions/UsersFunctions.php");
+
+    /*
+     * Read configuration from file...
+     */
+    $configFile = '/etc/resto/config.php';
+    if ( !file_exists($configFile)) {
+        exit(1);
+    }
+    $config = include($configFile);
+    $dbDriver = new RestoDatabaseDriver($config['database'] ?? null);
+    $queries = [];
+
+    $antimeridian = new AntiMeridian();
+
+    $targetSchema = $dbDriver->targetSchema;
+
+    try {
+        $dbDriver->query('ALTER TABLE ' . $targetSchema . '.catalog_feature ADD COLUMN IF NOT EXISTS created TIMESTAMP DEFAULT now()');
+    } catch(Exception $e){
+        RestoLogUtil::httpError(500, $e->getMessage());
+    }
+    echo "Looks good\n";
+    
+    

--- a/app/resto/core/RestoConstants.php
+++ b/app/resto/core/RestoConstants.php
@@ -20,7 +20,7 @@ class RestoConstants
     // [IMPORTANT] Starting resto 7.x, default routes are defined in RestoRouter class
 
     // resto version
-    const VERSION = '9.5.8';
+    const VERSION = '9.5.9';
 
     /* ============================================================
      *              NEVER EVER TOUCH THESE VALUES

--- a/app/resto/core/api/STACAPI.php
+++ b/app/resto/core/api/STACAPI.php
@@ -1640,13 +1640,11 @@ class STACAPI
                 $element = array(
                     'rel' => 'items',
                     'type' => RestoUtil::$contentTypes['geojson'],
-                    'href' => $this->context->core['baseUrl'] . ( str_starts_with($catalogId, 'collections/') ? '/' : '/catalogs/') .  join('/', array_map('rawurlencode', explode('/', $parentAndChilds['parent']['id']))) . '/_'
+                    'href' => $this->context->core['baseUrl'] . ( str_starts_with($catalogId, 'collections/') ? '/' : '/catalogs/') .  join('/', array_map('rawurlencode', explode('/', $parentAndChilds['parent']['id']))) . '/_',
+                    'title' => 'All items'
                 );
                 if ( $parentAndChilds['parent']['counters']['total'] > 0 ) {
                     $element['matched'] = $parentAndChilds['parent']['counters']['total'];
-                }
-                if ( isset($parentAndChilds['parent']['title']) ) {
-                    $element['title'] = $parentAndChilds['parent']['title'];
                 }
                 $parentAndChilds['childs'][] = $element;
             }

--- a/app/resto/core/dbfunctions/CatalogsFunctions.php
+++ b/app/resto/core/dbfunctions/CatalogsFunctions.php
@@ -202,7 +202,7 @@ class CatalogsFunctions
          * Delete (within transaction)
          */
         try {
-            $results = $this->dbDriver->pQuery('SELECT featureid, collection, title FROM ' . $this->dbDriver->targetSchema . '.catalog_feature WHERE path=$1::ltree', array(
+            $results = $this->dbDriver->pQuery('SELECT featureid, collection, title FROM ' . $this->dbDriver->targetSchema . '.catalog_feature WHERE path=$1::ltree ORDER BY created DESC', array(
                 RestoUtil::path2ltree($catalogId)
             ));    
         } catch (Exception $e) {
@@ -585,8 +585,8 @@ class CatalogsFunctions
         $properties = null;
         if ( isset($catalog['rtype']) && $catalog['rtype'] === 'collection' ) {
             $catalog = array_merge($catalog, [
-                'title' => null,
-                'description' => null,
+                /*'title' => null,
+                'description' => null,*/
                 'rtype' => 'collection'
             ]);
         }

--- a/app/resto/core/utils/antimeridian/LineString.php
+++ b/app/resto/core/utils/antimeridian/LineString.php
@@ -78,13 +78,13 @@ class LineString {
     }
 
     /**
-     * Check if the LineString is "clockwise".
+     * Check if the LineString is "counter clockwise".
      * LineStrings don't have a defined clockwise or counterclockwise orientation.
      * This method is here for consistency, but it will always return false for LineStrings.
      *
      * @return bool False for LineString, as orientation doesn't apply.
      */
-    public function isClockwise(): bool {
+    public function isCCW(): bool {
         return false;
     }
 

--- a/app/resto/core/utils/antimeridian/Polygon.php
+++ b/app/resto/core/utils/antimeridian/Polygon.php
@@ -1,36 +1,38 @@
 <?php
 
-class Polygon {
+class Polygon
+{
 
     private $exteriorRing; // Array of coordinates representing the exterior ring
     private $interiorRings = []; // Array of arrays, each representing an interior ring
 
-   /**
-    * Determine if a ring is oriented clockwise.
-    *
-    * @param array $ring The ring to check.
-    * @return bool True if the ring is clockwise, false otherwise.
-    */
-    public static function isClockwise(array $ring): bool {
-       $sum = 0;
-       $n = count($ring);
+    /**
+     * Determine if a ring is oriented CounterClockWise.
+     *
+     * @param array $ring The ring to check.
+     * @return bool True if the ring is ccw, false otherwise.
+     */
+    public static function isCCW(array $ring): bool
+    {
+        $area = 0.0;
+        $n = count($ring);
 
-       for ($i = 0; $i < $n - 1; $i++) {
-           $p1 = $ring[$i];
-           $p2 = $ring[$i + 1];
-           $sum += ($p2[0] - $p1[0]) * ($p2[1] + $p1[1]);
-       }
+        for ($i = 0; $i < $n - 1; $i++) {
+            $p1 = $ring[$i];
+            $p2 = $ring[$i + 1];
+            $area += ($p2[0] - $p1[0]) * ($p2[1] + $p1[1]);
+        }
 
-       return $sum > 0;
-   }
+        return $area < 0;
+    }
 
-    public function __construct(array $geoJsonGeometryOrSegment) {
-        
+    public function __construct(array $geoJsonGeometryOrSegment)
+    {
+
         if (array_is_list($geoJsonGeometryOrSegment)) {
             $geoJsonGeometryOrSegment[] = $geoJsonGeometryOrSegment[0];
             $this->exteriorRing = $geoJsonGeometryOrSegment;
-        }
-        else {
+        } else {
 
             if (!isset($geoJsonGeometryOrSegment['type']) || $geoJsonGeometryOrSegment['type'] !== 'Polygon') {
                 throw new Exception('Invalid GeoJSON: Must be of type Polygon');
@@ -56,7 +58,8 @@ class Polygon {
         }
     }
 
-    public function toGeoJSON(): array {
+    public function toGeoJSON(): array
+    {
 
         return [
             'type' => $this->getType(),
@@ -64,37 +67,44 @@ class Polygon {
         ];
     }
 
-    public function getExteriorRing(): array {
+    public function getExteriorRing(): array
+    {
         return $this->exteriorRing;
     }
 
-    public function getInteriorRings(): array {
+    public function getInteriorRings(): array
+    {
         return $this->interiorRings;
     }
 
-    public function setExteriorRing($exteriorRing) {
+    public function setExteriorRing($exteriorRing)
+    {
         $this->exteriorRing = $exteriorRing;
     }
 
-    public function setInteriorRings($interiorRings) {
+    public function setInteriorRings($interiorRings)
+    {
         $this->interiorRings = $interiorRings;
     }
 
-    private function isValidRing(array $ring): bool {
+    private function isValidRing(array $ring): bool
+    {
         return count($ring) >= 4 && $ring[0] === end($ring);
     }
 
-    public function getCoordinates(): array {
+    public function getCoordinates(): array
+    {
         $coordinates = [
             $this->exteriorRing
         ];
-        if ( !empty($this->interiorRings) ) {
+        if (!empty($this->interiorRings)) {
             $coordinates[] = $this->interiorRings;
         }
         return $coordinates;
     }
 
-    public function isCoincidentToAntimeridian(): bool {
+    public function isCoincidentToAntimeridian(): bool
+    {
         if ($this->checkRingCoincidence($this->exteriorRing)) {
             return true;
         }
@@ -108,7 +118,8 @@ class Polygon {
         return false;
     }
 
-    private function checkRingCoincidence(array $ring): bool {
+    private function checkRingCoincidence(array $ring): bool
+    {
         for ($i = 0; $i < count($ring) - 1; $i++) {
             $start = $ring[$i];
             $end = $ring[$i + 1];
@@ -125,13 +136,14 @@ class Polygon {
      *
      * @return bool True if the exterior ring is CCW and interior rings are CW.
      */
-    public function checkOrientation(): bool {
-        if (Polygon::isClockwise($this->exteriorRing)) {
+    public function checkOrientation(): bool
+    {
+        if (!Polygon::isCCW($this->exteriorRing)) {
             return false;
         }
 
         foreach ($this->interiorRings as $ring) {
-            if (!Polygon::isClockwise($ring)) {
+            if (Polygon::isCCW($ring)) {
                 return false;
             }
         }
@@ -143,13 +155,14 @@ class Polygon {
      * Correct the orientation of the rings.
      * Ensures the exterior ring is CCW and interior rings are CW.
      */
-    public function correctOrientation(): void {
-        if (Polygon::isClockwise($this->exteriorRing)) {
+    public function correctOrientation(): void
+    {
+        if (!Polygon::isCCW($this->exteriorRing)) {
             $this->exteriorRing = array_reverse($this->exteriorRing);
         }
 
         foreach ($this->interiorRings as &$ring) {
-            if (!Polygon::isClockwise($ring)) {
+            if (Polygon::isCCW($ring)) {
                 $ring = array_reverse($ring);
             }
         }
@@ -177,7 +190,8 @@ class Polygon {
      *
      * @return string The geometry type.
      */
-    public function getType(): string {
+    public function getType(): string
+    {
         return 'Polygon';
     }
 
@@ -203,12 +217,12 @@ class Polygon {
             $yj = $coords[$j][1];
 
             if (($yi > $y) != ($yj > $y) &&
-                $x < ($xj - $xi) * ($y - $yi) / ($yj - $yi) + $xi) {
+                $x < ($xj - $xi) * ($y - $yi) / ($yj - $yi) + $xi
+            ) {
                 $inside = !$inside;
             }
         }
 
         return $inside;
     }
-
 }

--- a/examples/items/dummy5_ccw.json
+++ b/examples/items/dummy5_ccw.json
@@ -1,0 +1,35 @@
+{
+    "id": "Dummy5",
+    "type": "Feature",
+    "properties": {
+        "datetime": "2024-06-21T16:27:00Z",
+        "description": "Dummy5"
+    },
+    "geometry": {
+        "coordinates": [
+            [
+                [
+                    -52,
+                    -65
+                ],
+                [
+                    159,
+                    -65
+                ],
+                [
+                    159,
+                    76
+                ],
+                [
+                    -52,
+                    76
+                ],
+                [
+                    -52,
+                    -65
+                ]
+            ]
+        ],
+        "type": "Polygon"
+    }
+}


### PR DESCRIPTION
* Set title to “All items” for the rel=”items” endpoint in catalogs instead of repeating the parent title
* Add a “created” column in catalog_feature table to order feature catalog by last inserted, first displayed
* The PHP antimeridian computation to split polygon that replaced the SQL code incorrectly split polygons that span more than 180 degrees in longitude. This does not work for global product. Hence, the hypothesis for split/no split is no more based on longitude length asumption but on the order of westernmost vs easternmost coordinates with the asumption that the first coordinates in the GeoJSON is always the westernmost coordinate (follows GeoJSON convention)
* Title and description of collection are now duplicated within the catalog table so a search in rocket correctly displayed it