### PR TITLE
[MAJOR] Add support for proxy of external catalog and limit user catalog creation to /catalogs/users/{username} path

### DIFF
--- a/admin_scripts/migrate_to_9.7.php
+++ b/admin_scripts/migrate_to_9.7.php
@@ -1,0 +1,35 @@
+#!/command/with-contenv php
+
+<?php
+
+    require_once("/app/resto/core/RestoConstants.php");
+    require_once("/app/resto/core/RestoDatabaseDriver.php");
+    require_once("/app/resto/core/utils/RestoLogUtil.php");
+    require_once("/app/resto/core/dbfunctions/UsersFunctions.php");
+
+    /*
+     * Read configuration from file...
+     */
+    $configFile = '/etc/resto/config.php';
+    if ( !file_exists($configFile)) {
+        exit(1);
+    }
+    $config = include($configFile);
+    $dbDriver = new RestoDatabaseDriver($config['database'] ?? null);
+    $queries = [];
+    try {
+
+        $dbDriver->query('BEGIN');
+
+        /* User name is now UNIQUE and called username */
+        $dbDriver->query('ALTER TABLE ' . $dbDriver->targetSchema . '.catalog ADD COLUMN IF NOT EXISTS stac_url TEXT');
+        
+        $dbDriver->query('COMMIT');
+
+    } catch(Exception $e){
+        $dbDriver->query('ROLLBACK');
+        RestoLogUtil::httpError(500, $e->getMessage());
+    }
+    echo "Looks good\n";
+    
+    

--- a/app/resto/core/RestoCollection.php
+++ b/app/resto/core/RestoCollection.php
@@ -980,9 +980,14 @@ class RestoCollection
             }
             // [IMPORTANT] Convert input names to ids
             $clean['visibility'] = (new GeneralFunctions($this->context->dbDriver))->visibilityNamesToIds($object['visibility']);
+            
             if ( empty($clean['visibility']) ) {
-                RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group');
+                RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
             }
+            if ( !(new catalogsFunctions($this->context->dbDriver))->canSeeCatalog($clean['visibility'], $this->user, true) ) {
+                RestoLogUtil::httpError(403, 'You are not allowed to set the visibility to a group you are not part of');
+            }
+        
         }
 
         /*

--- a/app/resto/core/RestoConstants.php
+++ b/app/resto/core/RestoConstants.php
@@ -20,7 +20,7 @@ class RestoConstants
     // [IMPORTANT] Starting resto 7.x, default routes are defined in RestoRouter class
 
     // resto version
-    const VERSION = '9.6.1';
+    const VERSION = '9.6.2';
 
     /* ============================================================
      *              NEVER EVER TOUCH THESE VALUES

--- a/app/resto/core/RestoConstants.php
+++ b/app/resto/core/RestoConstants.php
@@ -20,7 +20,7 @@ class RestoConstants
     // [IMPORTANT] Starting resto 7.x, default routes are defined in RestoRouter class
 
     // resto version
-    const VERSION = '9.6.2';
+    const VERSION = '9.7.0';
 
     /* ============================================================
      *              NEVER EVER TOUCH THESE VALUES

--- a/app/resto/core/RestoContext.php
+++ b/app/resto/core/RestoContext.php
@@ -71,6 +71,9 @@ class RestoContext
         // JSON Web Token validity duration (in seconds) - default is 100 days
         'tokenDuration' => 8640000,
 
+        // Display rel="items" link at every /catalogs/* level
+        'showItemsLink' => false,
+
         // Permanent storage directory to store/retrieve files
         'storageInfo' => array(
             'path' => '/var/www/static',

--- a/app/resto/core/RestoFeature.php
+++ b/app/resto/core/RestoFeature.php
@@ -104,9 +104,9 @@
  *              description="The date when the feature metadata was updated (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)"
  *          ),
  *          @OA\Property(
- *              property="published",
+ *              property="created",
  *              type="string",
- *              description="The date when the feature metadata was published (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)"
+ *              description="The date when the feature metadata was created (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)"
  *          ),
  *          @OA\Property(
  *              property="resto:catalogs",
@@ -213,7 +213,7 @@
  *              "end_datetime": "2020-06-21T11:11:28.371000Z",
  *              "productIdentifier": "S2B_MSIL1C_20200621T111039_N0209_R008_T28HCE_20200621T132349",
  *              "updated": "2018-09-13T12:52:25.971969Z",
- *              "published": "2018-09-13T12:52:25.971969Z",
+ *              "created": "2018-09-13T12:52:25.971969Z",
  *              "resto:catalogs": {
  *                   "ocean/SouthAtlanticOcean",
  *                   "landcover/water",

--- a/app/resto/core/RestoModel.php
+++ b/app/resto/core/RestoModel.php
@@ -47,14 +47,6 @@ abstract class RestoModel
     public $stacMapping = array(
 
         /*
-         * Common metadata
-         * [TODO][WARNING] The "published" metadata is part of https://github.com/stac-extensions/timestamps so we should not replace it with "created"
-         */
-        'published' => array(
-            'key' => 'created'
-        ),
-
-        /*
          * Processing Extension Specification
          * (https://stac-extensions.github.io/processing/v1.0.0/schema.json)
          */
@@ -261,7 +253,7 @@ abstract class RestoModel
 
         'dc:date' => array(
             'key' => 'created',
-            'osKey' => 'published',
+            'osKey' => 'created',
             'title' => 'Metadata product publication date within database - must follow RFC3339 pattern',
             'operation' => '>=',
             'pattern' => '^([0-9]{4})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))$'

--- a/app/resto/core/RestoModel.php
+++ b/app/resto/core/RestoModel.php
@@ -952,19 +952,27 @@ abstract class RestoModel
         }
 
         /*
-         * Convert visibility from names to ids
-         */
-        if ( isset($data['visibility']) ) {
-            $data['visibility'] = (new GeneralFunctions($collection->context->dbDriver))->visibilityNamesToIds($data['visibility']);
-            if ( empty($data['visibility']) ) {
-                RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
-            }
-        }
-
-        /*
          * Clean properties
          */
         $properties = RestoUtil::cleanAssociativeArray($data['properties']);
+
+        /*
+         * Convert visibility from names to ids
+         */
+        if ( isset($properties['visibility']) ) {
+            $properties['visibility'] = (new GeneralFunctions($collection->context->dbDriver))->visibilityNamesToIds($properties['visibility']);
+            if ( empty($properties['visibility']) ) {
+                RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
+            }
+
+            /*
+             * Check visibility
+             */
+            if ( !(new CatalogsFunctions($collection->context->dbDriver))->canSeeCatalog($properties['visibility'], $collection->user, true) ) {
+                RestoLogUtil::httpError(403, 'You are not allowed to set the visibility to a group you are not part of');
+            }
+
+        }
 
         /*
          * Convert datetime to startDate / completionDate

--- a/app/resto/core/RestoModel.php
+++ b/app/resto/core/RestoModel.php
@@ -254,10 +254,24 @@ abstract class RestoModel
         'dc:date' => array(
             'key' => 'created',
             'osKey' => 'created',
-            'title' => 'Metadata product publication date within database - must follow RFC3339 pattern',
+            'title' => 'Metadata creation date within database - must follow RFC3339 pattern. Single date+time, or a range ("/" separator) of the search query. Format should follow RFC-3339.',
+            'pattern' => '^(\.\.)|[(a-zA-Z0-9\-\/\.\:)]+$',
+        ),
+
+        'dc:start' => array(
+            'key' => 'created',
+            'osKey' => 'created_start',
             'operation' => '>=',
+            'title' => 'Beginning of the time slice of the metadata creation. Format should follow RFC-3339',
             'pattern' => '^([0-9]{4})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))$'
-            /*'pattern' => '^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(|Z|[\+\-][0-9]{2}:[0-9]{2}))?$'*/
+        ),
+        
+        'dc:end' => array(
+            'key' => 'created',
+            'osKey' => 'created_end',
+            'operation' => '<=',
+            'title' => 'End of the time slice of the metadata creation. Format should follow RFC-3339',
+            'pattern' => '^([0-9]{4})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))$'
         ),
 
         'resto:collection' => array(

--- a/app/resto/core/api/FeaturesAPI.php
+++ b/app/resto/core/api/FeaturesAPI.php
@@ -813,6 +813,9 @@ class FeaturesAPI
                 if ( empty($body[$property]) ) {
                     RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
                 }
+                if ( !(new CatalogsFunctions($this->context->dbDriver))->canSeeCatalog($body[$property], $this->user, true) ) {
+                    RestoLogUtil::httpError(403, 'You are not allowed to set the visibility to a group you are not part of');
+                }
             }
 
         }

--- a/app/resto/core/api/FeaturesAPI.php
+++ b/app/resto/core/api/FeaturesAPI.php
@@ -341,7 +341,7 @@ class FeaturesAPI
      *          )
      *      ),
      *      @OA\Parameter(
-     *          name="sort",
+     *          name="sortby",
      *          in="query",
      *          style="form",
      *          description="Sort results by property *startDate* or *created* (default *startDate*). Sorting order is DESCENDING (ASCENDING if property is prefixed by minus sign)",

--- a/app/resto/core/api/FeaturesAPI.php
+++ b/app/resto/core/api/FeaturesAPI.php
@@ -299,10 +299,10 @@ class FeaturesAPI
      *          )
      *      ),
      *      @OA\Parameter(
-     *          name="published",
+     *          name="created",
      *          in="query",
      *          style="form",
-     *          description="Returns products with metadata publication date greater or equal than *published* - OpenSearch {dc:date}",
+     *          description="Returns products with metadata publication date greater or equal than *created* - OpenSearch {dc:date}",
      *          required=false,
      *          @OA\Schema(
      *              type="string",

--- a/app/resto/core/api/STACAPI.php
+++ b/app/resto/core/api/STACAPI.php
@@ -1121,7 +1121,7 @@ class STACAPI
      *          )
      *      ),
      *      @OA\Parameter(
-     *          name="sort",
+     *          name="sortby",
      *          in="query",
      *          style="form",
      *          description="Sort results by property *startDate* or *created* (default *startDate*). Sorting order is DESCENDING (ASCENDING if property is prefixed by minus sign)",

--- a/app/resto/core/api/STACAPI.php
+++ b/app/resto/core/api/STACAPI.php
@@ -1463,7 +1463,7 @@ class STACAPI
             'id' => $segments[count($segments) -1 ],
             'title' => $parentAndChilds['parent']['title'] ?? '',
             'description' => $parentAndChilds['parent']['description'] ?? '',
-            'type' => 'Catalog',
+            'type' => ucfirst($parentAndChilds['parent']['rtype'] ?? 'catalog'),
             'links' => array_merge(
                 $this->getBaseLinks($segments),
                 !empty($parentAndChilds['parent']['links']) ? array_merge($parentAndChilds['childs'], $parentAndChilds['parent']['links']) : $parentAndChilds['childs']

--- a/app/resto/core/api/STACAPI.php
+++ b/app/resto/core/api/STACAPI.php
@@ -1636,7 +1636,7 @@ class STACAPI
         else {
 
             // Parent has an hashtag thus can have a rel="items" child to directly search for its contents
-            if ( $parentAndChilds['parent']['level'] > 1 ) {
+            if ( $parentAndChilds['parent']['level'] > 1 && $this->context->core['showItemsLink'] ) {
                 $element = array(
                     'rel' => 'items',
                     'type' => RestoUtil::$contentTypes['geojson'],

--- a/app/resto/core/api/STACAPI.php
+++ b/app/resto/core/api/STACAPI.php
@@ -414,6 +414,9 @@ class STACAPI
             if ( empty($body['visibility']) ) {
                 RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
             }
+            if ( !$this->catalogsFunctions->canSeeCatalog($body['visibility'], $this->user, true) ) {
+                RestoLogUtil::httpError(403, 'You are not allowed to sset the visibility to a group you are not part of');
+            }
         }
 
         // Owner of catalog can only be set by admin user

--- a/app/resto/core/api/STACAPI.php
+++ b/app/resto/core/api/STACAPI.php
@@ -415,7 +415,7 @@ class STACAPI
                 RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
             }
             if ( !$this->catalogsFunctions->canSeeCatalog($body['visibility'], $this->user, true) ) {
-                RestoLogUtil::httpError(403, 'You are not allowed to sset the visibility to a group you are not part of');
+                RestoLogUtil::httpError(403, 'You are not allowed to set the visibility to a group you are not part of');
             }
         }
 
@@ -550,8 +550,8 @@ class STACAPI
                 RestoLogUtil::httpError(400, 'Visibility is set but either emtpy or referencing an unknown group'); 
             }
 
-            if ( !$this->catalogsFunctions->canSeeCatalog($body['visibility'], $this->user) ) {
-                RestoLogUtil::httpError(403, 'You are not allowed to sset the visibility to a group you are not part of');
+            if ( !$this->catalogsFunctions->canSeeCatalog($body['visibility'], $this->user, true) ) {
+                RestoLogUtil::httpError(403, 'You are not allowed to set the visibility to a group you are not part of');
             }
 
         }

--- a/app/resto/core/api/ServicesAPI.php
+++ b/app/resto/core/api/ServicesAPI.php
@@ -158,14 +158,6 @@ class ServicesAPI
      *                  description="Server description"
      *              ),
      *              @OA\Property(
-     *                  property="capabilities",
-     *                  type="array",
-     *                  @OA\Items(
-     *                      type="string"
-     *                  ),
-     *                  description="Array of resto-addons list. Used client side to detect resto capabilities",
-     *              ),
-     *              @OA\Property(
      *                  property="links",
      *                  type="array",
      *                  @OA\Items(ref="#/components/schemas/Link")
@@ -187,7 +179,6 @@ class ServicesAPI
             'type' => 'Catalog',
             'title' => $this->title,
             'description' => $this->description,
-            'capabilities' => array_merge(array('resto-core'), array_map('strtolower', array_keys($this->context->addons))),
             'resto:version' => RestoConstants::VERSION,
             'ssys:targets' => array($this->context->core['planet']),
             'links' => array(
@@ -433,6 +424,6 @@ class ServicesAPI
      */
     private function conformsTo()
     {
-        return STACAPI::CONFORMANCE_CLASSES;
+        return array_merge(STACAPI::CONFORMANCE_CLASSES, array_map(fn($str) => 'https://api.snapplanet.io/v1.0.0/' . strtolower($str), array_keys(array_merge(array('resto-core' => 1), $this->context->addons))));
     }
 }

--- a/app/resto/core/api/UsersAPI.php
+++ b/app/resto/core/api/UsersAPI.php
@@ -602,7 +602,7 @@ class UsersAPI
         $owner = new RestoUser(array('username' => $params['username']), $this->context);
         return (new CatalogsFunctions($this->context->dbDriver))->getCatalogs(array(
             'where' => 'owner=' . $owner->profile['id']
-        ), $this->user, true);
+        ), true);
     }
 
     /**

--- a/app/resto/core/dbfunctions/CatalogsFunctions.php
+++ b/app/resto/core/dbfunctions/CatalogsFunctions.php
@@ -103,6 +103,27 @@ class CatalogsFunctions
     }
 
     /**
+     * 
+     * Return true if $user is allowed to see catalog
+     * 
+     * @param array $visibility
+     * @param RestoUser $user
+     * @return boolean
+     */
+    public function canSeeCatalog($visibility, $user)
+    {
+        if ( isset($visibility) ) {
+            for ($i = count($visibility); $i--;) {
+                if ( $user->hasGroup($visibility[$i]) ) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Get catalog
      *
      * @param string $id
@@ -116,20 +137,9 @@ class CatalogsFunctions
         ), false);
 
         if ( isset($catalogs) && count($catalogs) === 1) {
-
-            if ( $catalogs[0]['visibility'] ) {
-                $canSee = false;
-                for ($i = count($catalogs[0]['visibility']); $i--;) {
-                    if ( $user->hasGroup($catalogs[0]['visibility'][$i]) ) {
-                        $canSee = true;
-                        break;
-                    }
-                }
-                if ( !$canSee ) {
-                    RestoLogUtil::httpError(403, 'You are not allowed to access this catalog');
-                }
+            if ( !$this->canSeeCatalog($catalogs[0]['visibility'], $user) ) {
+                RestoLogUtil::httpError(403, 'You are not allowed to access this catalog');
             }
-            
             return $catalogs[0];
         }
 

--- a/app/resto/core/dbfunctions/FeaturesFunctions.php
+++ b/app/resto/core/dbfunctions/FeaturesFunctions.php
@@ -310,16 +310,18 @@ class FeaturesFunctions
      */
     public function storeFeature($id, $collection, $featureArray)
     {
-        
+       
         // Default visibility
-        $visibility = RestoUtil::getDefaultVisibility($collection->user, isset($collection->user->profile['settings']['createdItemIsPublic']) ? $collection->user->profile['settings']['createdItemIsPublic'] : true);
+        if ( !isset($featureArray['properties']['visibility']) ) {
+            $featureArray['properties']['visibility'] = RestoUtil::getDefaultVisibility($collection->user, isset($collection->user->profile['settings']['createdItemIsPublic']) ? $collection->user->profile['settings']['createdItemIsPublic'] : true);
+        }
         $keysAndValues = $this->featureArrayToKeysValues(
             $collection,
             $featureArray,
             array(
                 'id' => $id,
                 'collection' => $collection->id,
-                'visibility' => '{' . join(',', $visibility) . '}',
+                'visibility' => '{' . join(',', $featureArray['properties']['visibility']) . '}',
                 'owner' => isset($collection) && isset($collection->user) ? $collection->user->profile['id'] : null,
                 'status' => isset($featureArray['properties']) && isset($featureArray['properties']['status']) && is_int($featureArray['properties']['status']) ? $featureArray['properties']['status'] : 1,
                 'likes' => 0,

--- a/app/resto/core/dbfunctions/FeaturesFunctions.php
+++ b/app/resto/core/dbfunctions/FeaturesFunctions.php
@@ -347,7 +347,7 @@ class FeaturesFunctions
          */
         foreach (array_values($keysAndValues['catalogs']) as $catalog) {
             if (isset($catalog['isExternal']) && $catalog['isExternal']) {
-                if ( !$collection->user->hasRightsTo(RestoUser::CREATE_CATALOG) ) {
+                if ( !$collection->user->hasRightsTo(RestoUser::CREATE_CATALOG, array('catalog' => $catalog)) ) {
                     RestoLogUtil::httpError(403, 'Feature ingestion leads to creation of catalog ' . $catalog['id'] . ' but you don\'t have right to create catalogs');
                 }
                 break;
@@ -497,7 +497,7 @@ class FeaturesFunctions
          */
         foreach (array_values($keysAndValues['catalogs']) as $catalog) {
             if (isset($catalog['isExternal']) && $catalog['isExternal']) {
-                if ( !$collection->user->hasRightsTo(RestoUser::CREATE_CATALOG) ) {
+                if ( !$collection->user->hasRightsTo(RestoUser::CREATE_CATALOG, array('catalog' => $catalog)) ) {
                     RestoLogUtil::httpError(403, 'Feature update leads to creation of catalog ' . $catalog['id'] . ' but you don\'t have right to create catalogs');
                 }
                 break;

--- a/app/resto/core/dbfunctions/FiltersFunctions.php
+++ b/app/resto/core/dbfunctions/FiltersFunctions.php
@@ -301,7 +301,7 @@ class FiltersFunctions
          * [Issue][#267] Convert ',' to '.' character for seconds fraction since its a valid RFC339 (https://datatracker.ietf.org/doc/html/rfc3339)
          * but an invalid PostgreSQL date
          */
-        if (in_array($filterName, array('time:start', 'time:end', 'dc:date'))) {
+        if (in_array($filterName, array('time:start', 'time:end', 'dc:start', 'dc:end'))) {
             return array(
                 'value' => $this->optimizeNotEqual($paramsWithOperation[$filterName]['operation'], $this->addNot($exclusion) . $featureTableName . '.' . strtolower($this->model->searchFilters[$filterName]['key']) . '_idx ', ' timestamp_to_firstid(\'' . $this->context->dbDriver->escape_string(str_replace(',', '.', $paramsWithOperation[$filterName]['value'])) . '\')'),
                 'isGeo' => false

--- a/app/resto/core/dbfunctions/RightsFunctions.php
+++ b/app/resto/core/dbfunctions/RightsFunctions.php
@@ -21,6 +21,7 @@
  */
 class RightsFunctions
 {
+
     private $dbDriver = null;
 
     /**
@@ -193,6 +194,7 @@ class RightsFunctions
             RestoUser::DELETE_CATALOG => true,
             RestoUser::UPDATE_CATALOG => true,
 
+            RestoUser::CREATE_ANY_CATALOG => false,
             RestoUser::DELETE_ANY_CATALOG => false,
             RestoUser::UPDATE_ANY_CATALOG => false,
 

--- a/app/resto/core/dbfunctions/UsersFunctions.php
+++ b/app/resto/core/dbfunctions/UsersFunctions.php
@@ -389,6 +389,10 @@ class UsersFunctions
                 $group['id'],
                 $outputProfile['id']
             ));
+
+            // Finally create user catalog under /catalogs/users
+            // [TODO] Issue there since it only creates the catalog within targetSchema not all the potential schemas ...
+            $this->createUserCatalog($outputProfile, $group['id']);
             
             $this->dbDriver->query('COMMIT');
 
@@ -635,5 +639,27 @@ class UsersFunctions
         }
 
         RestoLogUtil::httpError(400, 'Invalid picture');
+    }
+
+    /**
+     * Create user's private catalog
+     * 
+     * @param array $profile
+     * @param string $groupId
+     */
+    public function createUserCatalog($profile, $groupId) {
+
+        $this->dbDriver->query_params('INSERT INTO ' . $this->dbDriver->targetSchema . '.catalog (id, title, description, level, counters, owner, visibility, created) VALUES ($1,$2,$3,$4,$5,$6,$7,now_utc()) ON CONFLICT (id) DO NOTHING', array(
+            'users/' . $profile['username'],
+            'Private catalog',
+            'This is ' . $profile['username'] . ' private catalog',
+            2,
+            str_replace('[]', '{}', json_encode(array(
+                'total' => 0,
+                'collections' => array()
+            ), JSON_UNESCAPED_SLASHES)),
+            $profile['id'],
+            '{' . $groupId . '}'
+        ));   
     }
 }

--- a/app/resto/core/dbfunctions/UsersFunctions.php
+++ b/app/resto/core/dbfunctions/UsersFunctions.php
@@ -651,7 +651,7 @@ class UsersFunctions
 
         $this->dbDriver->query_params('INSERT INTO ' . $this->dbDriver->targetSchema . '.catalog (id, title, description, level, counters, owner, visibility, created) VALUES ($1,$2,$3,$4,$5,$6,$7,now_utc()) ON CONFLICT (id) DO NOTHING', array(
             'users/' . $profile['username'],
-            'Private catalog',
+            $profile['username'],
             'This is ' . $profile['username'] . ' private catalog',
             2,
             str_replace('[]', '{}', json_encode(array(

--- a/app/resto/core/utils/RestoFeatureUtil.php
+++ b/app/resto/core/utils/RestoFeatureUtil.php
@@ -200,7 +200,7 @@ class RestoFeatureUtil
                     break;
 
                 case 'visibility':
-                    $featureArray['visibility'] = explode(',', (substr($value, 1, strlen($value) - 2)));
+                    $featureArray['visibility'] = RestoUtil::SQLTextArrayToPHP($value);
                     break;
 
                 case 'bbox4326':

--- a/app/resto/core/utils/RestoFeatureUtil.php
+++ b/app/resto/core/utils/RestoFeatureUtil.php
@@ -200,7 +200,7 @@ class RestoFeatureUtil
                     break;
 
                 case 'visibility':
-                    $featureArray['visibility'] = RestoUtil::SQLTextArrayToPHP($value);
+                    $featureArray['properties']['visibility'] = RestoUtil::SQLTextArrayToPHP($value);
                     break;
 
                 case 'bbox4326':

--- a/app/resto/core/utils/RestoUtil.php
+++ b/app/resto/core/utils/RestoUtil.php
@@ -577,7 +577,6 @@ class RestoUtil
             $ownedGroups = $user->getOwnedGroups();
             for ($i = 0, $ii = count($ownedGroups); $i < $ii; $i++) {
                 if ( $ownedGroups[$i]['private'] === "1" ) {
-
                     return array($ownedGroups[$i]['id']);
                 }
             }

--- a/app/resto/core/utils/STACUtil.php
+++ b/app/resto/core/utils/STACUtil.php
@@ -18,6 +18,16 @@
 class STACUtil
 {
 
+    /*
+     * Reserved catalog paths
+     * These paths are reserved for internal use
+     */
+    const RESERVED_CATALOG_PATHS = array(
+        'collections',
+        'users',
+        'projects'
+    );
+
     public static $extensions = array(
         'acuracy' => array(
             'id' => ' https://stac-extensions.github.io/accuracy/v1.0.0-beta.1/schema.json',

--- a/app/resto/core/utils/STACUtil.php
+++ b/app/resto/core/utils/STACUtil.php
@@ -461,4 +461,29 @@ class STACUtil
         )
     );
 
+    /**
+     * Return an external STAC catalog
+     * 
+     * @param string $url
+     * @return array
+     */
+    public static function resolveEndpoint($url)
+    {
+        try {
+            $curl = new Curly();
+            $response = json_decode($curl->get($url), true);
+            $httpStatus = curl_getinfo($curl->handler, CURLINFO_HTTP_CODE);
+            $curl->close();
+        } catch (Exception $e) {
+            $curl->close();
+            return RestoLogUtil::httpError($e->getCode(), $e->getMessage());
+        }
+
+        if ( $httpStatus !== 200 ) {
+            return RestoLogUtil::httpError($httpStatus);
+        }
+
+        return $response;
+    }
+
 }

--- a/build/resto/config.php.template
+++ b/build/resto/config.php.template
@@ -22,6 +22,7 @@ return array(
     'documentationUrl' => '${DOCUMENTATION_URL}',
     'useCache' => ${USE_CACHE:-false}, 
     'useJSONLD' => ${USE_JSONLD:-false},
+    'showItemsLink' => ${SHOW_ITEMS_LINK:-false},
     'corsWhiteList' => array(${CORS_WHITELIST}),
     'htmlSearchEndpoint' => '${SEARCH_OPENSEARCH_HTML_ENDPOINT}',
     'database' => array(

--- a/build/resto/container_root/cont-init.d/18-resto-admin-user.php
+++ b/build/resto/container_root/cont-init.d/18-resto-admin-user.php
@@ -18,7 +18,7 @@
     $config = include($configFile);
     
     $dbDriver = new RestoDatabaseDriver($config['database'] ?? null);
-    $dbDriver->pQuery('INSERT INTO ' . $dbDriver->commonSchema . '.user (id,username,email,password,activated,registrationdate) VALUES ($1,$2,$3,$4,1,now_utc()) ON CONFLICT (id) DO UPDATE SET password=$3', array(
+    $dbDriver->pQuery('INSERT INTO ' . $dbDriver->commonSchema . '.user (id,username,email,password,activated,registrationdate) VALUES ($1,$2,$3,$4,1,now_utc()) ON CONFLICT (id) DO UPDATE SET password=$4', array(
         RestoConstants::ADMIN_USER_ID,
         getenv('ADMIN_USER_NAME') ?? 'admin',
         getenv('ADMIN_USER_NAME') ?? 'admin@localhost',

--- a/build/resto/container_root/cont-init.d/19-resto-create-user-catalog.php
+++ b/build/resto/container_root/cont-init.d/19-resto-create-user-catalog.php
@@ -1,0 +1,47 @@
+#!/command/with-contenv php
+
+<?php
+
+    require_once("/app/resto/core/RestoConstants.php");
+    require_once("/app/resto/core/RestoDatabaseDriver.php");
+    require_once("/app/resto/core/utils/RestoLogUtil.php");
+    require_once("/app/resto/core/dbfunctions/UsersFunctions.php");
+
+    /*
+     * Read configuration from file...
+     */
+    $configFile = '/etc/resto/config.php';
+    if ( !file_exists($configFile)) {
+        exit(1);
+    }
+
+    $config = include($configFile);
+    $dbDriver = new RestoDatabaseDriver($config['database'] ?? null);
+    $restoUserFunctions = new UsersFunctions($dbDriver);
+
+    $allUsers = array();
+    try {
+
+        $dbDriver->query_params('INSERT INTO ' . $dbDriver->targetSchema . '.catalog (id, title, description, level, counters, owner, visibility, created) VALUES ($1,$2,$3,$4,$5,$6,$7,now_utc()) ON CONFLICT (id) DO NOTHING', array(
+            'users',
+            'Users catalog',
+            'Catalog for each users',
+            1,
+            str_replace('[]', '{}', json_encode(array(
+                'total' => 0,
+                'collections' => array()
+            ), JSON_UNESCAPED_SLASHES)),
+            RestoConstants::ADMIN_USER_ID,
+            '{' . RestoConstants::GROUP_DEFAULT_ID . '}'
+        ));   
+        
+        $allUsers = $dbDriver->fetch($dbDriver->query('SELECT u.id AS userid, u.username AS username, g.id AS groupid FROM ' . $dbDriver->commonSchema . '.user u,' . $dbDriver->commonSchema . '.group g WHERE g.owner = u.id AND g.name = u.username || \'_private\''));
+        for ($i = 0; $i < count($allUsers); $i++) {
+            $restoUserFunctions->createUserCatalog(array(
+                'id' => $allUsers[$i]['userid'],
+                'username' => $allUsers[$i]['username'],
+            ), $allUsers[$i]['groupid']);
+        }
+    } catch (Exception $e) {
+        exit(1);
+    }

--- a/config.env
+++ b/config.env
@@ -120,6 +120,9 @@ JWT_PASSPHRASE="Super secret passphrase"
 ### True to provide additionnal JSON-LD metadata within catalogs/collections/items
 #USE_JSONLD=false
 
+### True to provide direct access to rel="items" at every /catalogs/* level
+#SHOW_ITEMS_LINK=false
+
 ### =====================================================================
 ### Search engine configuration
 ### =====================================================================

--- a/docs/COLLECTIONS_CATALOGS_ITEMS.md
+++ b/docs/COLLECTIONS_CATALOGS_ITEMS.md
@@ -53,23 +53,31 @@ Then get the item :
 ## Catalogs
 
 ### Add a catalog
+User with catalog creation right can create a catalog i.e.:
+* The "createCatalog" right allows user to create catalog within its private space i.e. under /catalogs/users/{username}
+* The "createAnyCatalog" right allows user to create catalog anywhere **except the private space of another user**
 
-        # Create a catalog - user with the "createCatalog" right can create a catalog 
+For instance, user "johndoe" has the "createCatalog" right and can create a catalog only under its private space:
+
+        curl -X POST -d@examples/catalogs/dummyCatalog.json "http://johndoe:dummy@localhost:5252/catalogs/users/johndoe"
+
+Admin user has the "createAnyCatalog" right and can create a catalog anywhere:
+
         curl -X POST -d@examples/catalogs/dummyCatalog.json "http://admin:admin@localhost:5252/catalogs"
 
 ### Reserved catalog names
-The following paths are reserved i.e. created by resto itself:
+The following paths are reserved and cannot be created by a user whatever its rights:
 * /catalogs/collections
 * /catalogs/projects
 * /catalogs/users
 
-        # A catalog at the root level cannot be named "collections" because it is a reserved catalog name
-        curl -X POST -d@examples/catalogs/invalidCatalogInRoot.json "http://admin:admin@localhost:5252/catalogs"
+### Catalog /catalogs/users
+No user can create a catalog directly under /catalogs/users catalog neither can create a catalog under a another user catalog.
+For instance "johndoe" user cannot create a catalog under /catalog/users/janedoe even if he get the "createAnyCatalog" right
 
 ### Add a catalog under an existing catalog
-
 **[IMPORTANT]** You cannot create a catalog with childs in links because a child cannot exist before its parent. The good way
-is to create an empty catalog then add its childs through the POST API
+is to create first an empty catalog (i.e. the parent) then add its childs through the POST API
 
         # This will raise an error because the catalog references childs that do not exist.
         curl -X POST -d@examples/catalogs/dummyCatalogWithChilds_invalid.json "http://admin:admin@localhost:5252/catalogs"

--- a/docs/COLLECTIONS_CATALOGS_ITEMS.md
+++ b/docs/COLLECTIONS_CATALOGS_ITEMS.md
@@ -57,7 +57,11 @@ Then get the item :
         # Create a catalog - user with the "createCatalog" right can create a catalog 
         curl -X POST -d@examples/catalogs/dummyCatalog.json "http://admin:admin@localhost:5252/catalogs"
 
-### Invalid catalog
+### Reserved catalog names
+The following paths are reserved i.e. created by resto itself:
+* /catalogs/collections
+* /catalogs/projects
+* /catalogs/users
 
         # A catalog at the root level cannot be named "collections" because it is a reserved catalog name
         curl -X POST -d@examples/catalogs/invalidCatalogInRoot.json "http://admin:admin@localhost:5252/catalogs"
@@ -66,6 +70,7 @@ Then get the item :
 
 **[IMPORTANT]** You cannot create a catalog with childs in links because a child cannot exist before its parent. The good way
 is to create an empty catalog then add its childs through the POST API
+
         # This will raise an error because the catalog references childs that do not exist.
         curl -X POST -d@examples/catalogs/dummyCatalogWithChilds_invalid.json "http://admin:admin@localhost:5252/catalogs"
 

--- a/docs/COLLECTIONS_CATALOGS_ITEMS.md
+++ b/docs/COLLECTIONS_CATALOGS_ITEMS.md
@@ -71,7 +71,7 @@ The following paths are reserved and cannot be created by a user whatever its ri
 * /catalogs/projects
 * /catalogs/users
 
-### Catalog /catalogs/users
+#### Catalog /catalogs/users
 No user can create a catalog directly under /catalogs/users catalog neither can create a catalog under a another user catalog.
 For instance "johndoe" user cannot create a catalog under /catalog/users/janedoe even if he get the "createAnyCatalog" right
 
@@ -87,11 +87,11 @@ is to create first an empty catalog (i.e. the parent) then add its childs throug
         curl -X POST -d@examples/catalogs/dummyCatalogChild1.json "http://admin:admin@localhost:5252/catalogs/dummyCatalogWithChilds"
         curl -X POST -d@examples/catalogs/dummyCatalogChild2.json "http://admin:admin@localhost:5252/catalogs/dummyCatalogWithChilds"
 
-#### Add a collection under an existing catalog
+### Add a collection under an existing catalog
 
         curl -X POST -d@examples/collections/DummyCollection.json "http://admin:admin@localhost:5252/catalogs/dummyCatalogWithChilds"
 
-## Add a catalog under an existing catalog that cycle on itself
+### Add a catalog under an existing catalog that cycle on itself
 
         # The catalog dummyCatalogCycling is posted under /catalogs/dummyCatalogChild1 but reference one of this
         # parent as a child which is forbiden
@@ -110,6 +110,11 @@ is to create first an empty catalog (i.e. the parent) then add its childs throug
         curl -X POST -d@examples/items/dummySargasse.json "http://admin:admin@localhost:5252/collections/DummyCollection/items"
 
         curl -X POST -d@examples/catalogs/dummyCatalogWithItem.json "http://admin:admin@localhost:5252/catalogs/dummyCatalogWithChilds/dummyCatalogChild1"
+
+### Add an external catalog
+If you POST a catalog with a rel="root" link pointing to an external STAC href, then the resto will act as a proxy to this catalog
+
+        curl -X POST -d@examples/catalogs/externalCatalog.json "http://admin:admin@localhost:5252/catalogs"
 
 ### Update a catalog
 

--- a/docs/USERS_AND_RIGHTS.md
+++ b/docs/USERS_AND_RIGHTS.md
@@ -288,15 +288,15 @@ John Doe change the visibility of the JohnDoeCollection to dummyGroup only:
 #### Create a catalog to make it visible only to a group
 John Doe creates a catalog that is only visible by dummyGroup:
 
-        curl -X POST -d@examples/catalogs/JohnDoeCatalog.json "http://johnDoe%40localhost:dummy@localhost:5252/catalogs"
+        curl -X POST -d@examples/catalogs/JohnDoeCatalog.json "http://johnDoe%40localhost:dummy@localhost:5252/catalogs/users/johndoe"
 
         # The catalog is not visible to users
-        curl "http://localhost:5252/catalogs"
+        curl "http://localhost:5252/catalogs/users/johndoe"
 
         # Except to users belonging to dummyGroup (like John Doe)
-        curl "http://johnDoe%40localhost:dummy@localhost:5252/catalogs"
+        curl "http://johnDoe%40localhost:dummy@localhost:5252/catalogs/users/johndoe"
 
 #### Update a catalog to make it visible for everyone
 John Doe change visibility to default group so everyone can see it:
 
-        curl -X PUT -d@examples/catalogs/JohnDoeCatalog_update.json "http://johnDoe%40localhost:dummy@localhost:5252/catalogs/JohnDoeCatalog"
+        curl -X PUT -d@examples/catalogs/JohnDoeCatalog_update.json "http://johnDoe%40localhost:dummy@localhost:5252/catalogs/users/johndoe/JohnDoeCatalog"

--- a/docs/USERS_AND_RIGHTS.md
+++ b/docs/USERS_AND_RIGHTS.md
@@ -84,7 +84,7 @@ The rights defines access to resto ressources in particular to authorize CRUD op
 rights are defined as boolean properties within a JSON object. The default user's rights are the following:
 
         {
-                // If true the user can create a collection
+                // If true the user can create a collection (i.e. under /collections)
                 "createCollection": false,
 
                 // If true the user can delete a collection he owns
@@ -99,7 +99,7 @@ rights are defined as boolean properties within a JSON object. The default user'
                 // If true the user can update any collection whether he owns it or not
                 "updateAnyCollection": false,
                 
-                // If true the user can create a catalog
+                // If true the user can create a catalog in its user's private catalog (i.e. under /catalogs/users/{username})
                 "createCatalog": true,
 
                 // If true the user can delete a catalog he owns
@@ -107,6 +107,9 @@ rights are defined as boolean properties within a JSON object. The default user'
 
                 // If true the user can update a catalog he owns
                 "updateCatalog": true,
+
+                // If true the user can create a catalog anywhere (except in another user private catalog)
+                "createAnyCatalog": false,
 
                 // If true the user can delete any catalog whether he owns it or not
                 "deleteAnyCatalog": false,

--- a/docs/api/resto-api.html
+++ b/docs/api/resto-api.html
@@ -1496,7 +1496,7 @@ var n=this.pipeline.run(e.tokenizer(t)),r=new e.Vector,i=[],o=this._fields.reduc
 	  	<ul class="toc-list-h1">
         
           <li>
-            <a href="#welcome-to-resto" class="toc-h1 toc-link" data-title="Welcome to resto v9.3.0">Welcome to resto v9.3.0</a>
+            <a href="#welcome-to-resto" class="toc-h1 toc-link" data-title="Welcome to resto v9.6.2">Welcome to resto v9.6.2</a>
             
           </li>
         
@@ -1625,6 +1625,21 @@ var n=this.pipeline.run(e.tokenizer(t)),r=new e.Vector,i=[],o=this._fields.reduc
                 
                   <li>
                     <a href="#usersapi--updateuserprofile" class="toc-h2 toc-link" data-title="UsersAPI::updateUserProfile">UsersAPI::updateUserProfile</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#usersapi--getusercatalogs" class="toc-h2 toc-link" data-title="UsersAPI::getUserCatalogs">UsersAPI::getUserCatalogs</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#usersapi--getusercollections" class="toc-h2 toc-link" data-title="UsersAPI::getUserCollections">UsersAPI::getUserCollections</a>
+                    
+                  </li>
+                
+                  <li>
+                    <a href="#usersapi--getuserfeatures" class="toc-h2 toc-link" data-title="UsersAPI::getUserFeatures">UsersAPI::getUserFeatures</a>
                     
                   </li>
                 
@@ -1931,7 +1946,7 @@ var n=this.pipeline.run(e.tokenizer(t)),r=new e.Vector,i=[],o=this._fields.reduc
     <div class="page-wrapper">
       <div class="dark-box"></div>
       <div class="content">
-        <h1 id="welcome-to-resto">Welcome to resto v9.3.0</h1>
+        <h1 id="welcome-to-resto">Welcome to resto v9.6.2</h1>
 <blockquote>
 <p>Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.</p>
 </blockquote>
@@ -2031,7 +2046,7 @@ curl -X GET http://127.0.0.1:5252/collections \
         <span class="hljs-string">"level1C"</span>,
         <span class="hljs-string">"USGS"</span>
       ],
-      <span class="hljs-attr">"license"</span>: <span class="hljs-string">"proprietary"</span>,
+      <span class="hljs-attr">"license"</span>: <span class="hljs-string">"other"</span>,
       <span class="hljs-attr">"extent"</span>: {
         <span class="hljs-attr">"spatial"</span>: {
           <span class="hljs-attr">"bbox"</span>: [
@@ -2214,7 +2229,7 @@ curl -X GET http://127.0.0.1:5252/collections \
 <td>string</td>
 <td>true</td>
 <td>none</td>
-<td>License for this collection as a SPDX License identifier or expression. Alternatively, use proprietary if the license is not on the SPDX license list or various if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the license link relation type.</td>
+<td>License for this collection as a SPDX License identifier or expression. Alternatively, use other if the license is not on the SPDX license list. In this case, links to the license texts SHOULD be added, see the license link relation type.</td>
 </tr>
 <tr>
 <td>»» extent</td>
@@ -2345,11 +2360,7 @@ curl -X GET http://127.0.0.1:5252/collections \
 </tr>
 <tr>
 <td>license</td>
-<td>proprietary</td>
-</tr>
-<tr>
-<td>license</td>
-<td>various</td>
+<td>other</td>
 </tr>
 <tr>
 <td>license</td>
@@ -2387,7 +2398,7 @@ curl -X POST http://127.0.0.1:5252/collections \
   <span class="hljs-attr">"visibility"</span>: [
     <span class="hljs-string">"default"</span>
   ],
-  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"proprietary"</span>,
+  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"other"</span>,
   <span class="hljs-attr">"providers"</span>: [
     {
       <span class="hljs-attr">"name"</span>: <span class="hljs-string">"European Union/ESA/Copernicus"</span>,
@@ -2406,7 +2417,7 @@ curl -X POST http://127.0.0.1:5252/collections \
     }
   ],
   <span class="hljs-attr">"summaries"</span>: {
-    <span class="hljs-attr">"eo:bands"</span>: [
+    <span class="hljs-attr">"bands"</span>: [
       {
         <span class="hljs-attr">"name"</span>: <span class="hljs-string">"B1"</span>,
         <span class="hljs-attr">"common_name"</span>: <span class="hljs-string">"coastal"</span>,
@@ -2653,7 +2664,7 @@ curl -X GET http://127.0.0.1:5252/collections/{collectionId} \
     <span class="hljs-string">"sentinel"</span>,
     <span class="hljs-string">"sentinel2"</span>
   ],
-  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"proprietary"</span>,
+  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"other"</span>,
   <span class="hljs-attr">"extent"</span>: {
     <span class="hljs-attr">"spatial"</span>: {
       <span class="hljs-attr">"bbox"</span>: [
@@ -2730,7 +2741,7 @@ curl -X GET http://127.0.0.1:5252/collections/{collectionId} \
     <span class="hljs-attr">"productType"</span>: [
       <span class="hljs-string">"REFLECTANCE"</span>
     ],
-    <span class="hljs-attr">"eo:bands"</span>: [
+    <span class="hljs-attr">"bands"</span>: [
       {
         <span class="hljs-attr">"name"</span>: <span class="hljs-string">"B1"</span>,
         <span class="hljs-attr">"common_name"</span>: <span class="hljs-string">"coastal"</span>,
@@ -2867,7 +2878,7 @@ curl -X PUT http://127.0.0.1:5252/collections/{collectionId} \
   <span class="hljs-attr">"visibility"</span>: [
     <span class="hljs-string">"default"</span>
   ],
-  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"proprietary"</span>,
+  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"other"</span>,
   <span class="hljs-attr">"providers"</span>: [
     {
       <span class="hljs-attr">"name"</span>: <span class="hljs-string">"European Union/ESA/Copernicus"</span>,
@@ -2886,7 +2897,7 @@ curl -X PUT http://127.0.0.1:5252/collections/{collectionId} \
     }
   ],
   <span class="hljs-attr">"summaries"</span>: {
-    <span class="hljs-attr">"eo:bands"</span>: [
+    <span class="hljs-attr">"bands"</span>: [
       {
         <span class="hljs-attr">"name"</span>: <span class="hljs-string">"B1"</span>,
         <span class="hljs-attr">"common_name"</span>: <span class="hljs-string">"coastal"</span>,
@@ -3646,11 +3657,11 @@ curl -X GET http://127.0.0.1:5252/collections/{collectionId}/items \
 <td>End of the time slice of the search query. Format should follow RFC-3339 - OpenSearch {time:end}</td>
 </tr>
 <tr>
-<td>published</td>
+<td>created</td>
 <td>query</td>
 <td>string(date-time)</td>
 <td>false</td>
-<td>Returns products with metadata publication date greater or equal than <em>published</em> - OpenSearch {dc:date}</td>
+<td>Returns products with metadata publication date greater or equal than <em>created</em> - OpenSearch {dc:date}</td>
 </tr>
 <tr>
 <td>prev</td>
@@ -3674,7 +3685,7 @@ curl -X GET http://127.0.0.1:5252/collections/{collectionId}/items \
 <td>Like on product identifier</td>
 </tr>
 <tr>
-<td>sort</td>
+<td>sortby</td>
 <td>query</td>
 <td>string</td>
 <td>false</td>
@@ -4109,7 +4120,7 @@ curl -X GET http://127.0.0.1:5252/collections/{collectionId}/items/{featureId} \
     <span class="hljs-attr">"end_datetime"</span>: <span class="hljs-string">"2020-06-21T11:11:28.371000Z"</span>,
     <span class="hljs-attr">"productIdentifier"</span>: <span class="hljs-string">"S2B_MSIL1C_20200621T111039_N0209_R008_T28HCE_20200621T132349"</span>,
     <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
+    <span class="hljs-attr">"created"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
     <span class="hljs-attr">"resto:catalogs"</span>: [
       <span class="hljs-string">"ocean/SouthAtlanticOcean"</span>,
       <span class="hljs-string">"landcover/water"</span>,
@@ -4852,7 +4863,7 @@ curl -X GET http://127.0.0.1:5252/search \
 <td>Like on product identifier</td>
 </tr>
 <tr>
-<td>sort</td>
+<td>sortby</td>
 <td>query</td>
 <td>string</td>
 <td>false</td>
@@ -6465,6 +6476,240 @@ curl -X PUT http://127.0.0.1:5252/users/{username} \
 </tr>
 </tbody>
 </table>
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+basicAuth & bearerAuth & queryAuth
+</aside>
+<h2 id="usersapi--getusercatalogs">UsersAPI::getUserCatalogs</h2>
+<p><a id="opIdUsersAPI::getUserCatalogs"></a></p>
+<blockquote>
+<p>Code samples</p>
+</blockquote>
+<pre class="highlight tab tab-shell"><code><span class="hljs-comment"># You can also use wget</span>
+curl -X GET http://127.0.0.1:5252/users/{username}/catalogs \
+  -H <span class="hljs-string">'Accept: application/json'</span> \
+  -H <span class="hljs-string">'Authorization: Bearer {access-token}'</span>
+
+</code></pre>
+<p><code>GET /users/{username}/catalogs</code></p>
+<p><em>Get user's catalogs</em></p>
+<h3 id="usersapi--getusercatalogs-parameters">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>In</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>username</td>
+<td>path</td>
+<td>string</td>
+<td>true</td>
+<td>User name</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>Example responses</p>
+</blockquote>
+<blockquote>
+<p>200 Response</p>
+</blockquote>
+<pre class="highlight tab tab-json"><code><span class="hljs-literal">null</span>
+</code></pre>
+<h3 id="usersapi--getusercatalogs-responses">Responses</h3>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Meaning</th>
+<th>Description</th>
+<th>Schema</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>200</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">OK</a></td>
+<td>User catalogs</td>
+<td>Inline</td>
+</tr>
+<tr>
+<td>401</td>
+<td><a href="https://tools.ietf.org/html/rfc7235#section-3.1">Unauthorized</a></td>
+<td>Unauthorized</td>
+<td><a href="#schemaunauthorizederror">UnauthorizedError</a></td>
+</tr>
+<tr>
+<td>404</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">Not Found</a></td>
+<td>Resource not found</td>
+<td><a href="#schemanotfounderror">NotFoundError</a></td>
+</tr>
+</tbody>
+</table>
+<h3 id="usersapi--getusercatalogs-responseschema">Response Schema</h3>
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+basicAuth & bearerAuth & queryAuth
+</aside>
+<h2 id="usersapi--getusercollections">UsersAPI::getUserCollections</h2>
+<p><a id="opIdUsersAPI::getUserCollections"></a></p>
+<blockquote>
+<p>Code samples</p>
+</blockquote>
+<pre class="highlight tab tab-shell"><code><span class="hljs-comment"># You can also use wget</span>
+curl -X GET http://127.0.0.1:5252/users/{username}/collections \
+  -H <span class="hljs-string">'Accept: application/json'</span> \
+  -H <span class="hljs-string">'Authorization: Bearer {access-token}'</span>
+
+</code></pre>
+<p><code>GET /users/{username}/collections</code></p>
+<p><em>Get user's collections</em></p>
+<h3 id="usersapi--getusercollections-parameters">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>In</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>username</td>
+<td>path</td>
+<td>string</td>
+<td>true</td>
+<td>User name</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>Example responses</p>
+</blockquote>
+<blockquote>
+<p>200 Response</p>
+</blockquote>
+<pre class="highlight tab tab-json"><code><span class="hljs-literal">null</span>
+</code></pre>
+<h3 id="usersapi--getusercollections-responses">Responses</h3>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Meaning</th>
+<th>Description</th>
+<th>Schema</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>200</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">OK</a></td>
+<td>User collections</td>
+<td>Inline</td>
+</tr>
+<tr>
+<td>401</td>
+<td><a href="https://tools.ietf.org/html/rfc7235#section-3.1">Unauthorized</a></td>
+<td>Unauthorized</td>
+<td><a href="#schemaunauthorizederror">UnauthorizedError</a></td>
+</tr>
+<tr>
+<td>404</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">Not Found</a></td>
+<td>Resource not found</td>
+<td><a href="#schemanotfounderror">NotFoundError</a></td>
+</tr>
+</tbody>
+</table>
+<h3 id="usersapi--getusercollections-responseschema">Response Schema</h3>
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+basicAuth & bearerAuth & queryAuth
+</aside>
+<h2 id="usersapi--getuserfeatures">UsersAPI::getUserFeatures</h2>
+<p><a id="opIdUsersAPI::getUserFeatures"></a></p>
+<blockquote>
+<p>Code samples</p>
+</blockquote>
+<pre class="highlight tab tab-shell"><code><span class="hljs-comment"># You can also use wget</span>
+curl -X GET http://127.0.0.1:5252/users/{username}/features \
+  -H <span class="hljs-string">'Accept: application/json'</span> \
+  -H <span class="hljs-string">'Authorization: Bearer {access-token}'</span>
+
+</code></pre>
+<p><code>GET /users/{username}/features</code></p>
+<p><em>Get user's features</em></p>
+<h3 id="usersapi--getuserfeatures-parameters">Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>In</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>username</td>
+<td>path</td>
+<td>string</td>
+<td>true</td>
+<td>User name</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>Example responses</p>
+</blockquote>
+<blockquote>
+<p>200 Response</p>
+</blockquote>
+<pre class="highlight tab tab-json"><code><span class="hljs-literal">null</span>
+</code></pre>
+<h3 id="usersapi--getuserfeatures-responses">Responses</h3>
+<table>
+<thead>
+<tr>
+<th>Status</th>
+<th>Meaning</th>
+<th>Description</th>
+<th>Schema</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>200</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">OK</a></td>
+<td>User features</td>
+<td>Inline</td>
+</tr>
+<tr>
+<td>401</td>
+<td><a href="https://tools.ietf.org/html/rfc7235#section-3.1">Unauthorized</a></td>
+<td>Unauthorized</td>
+<td><a href="#schemaunauthorizederror">UnauthorizedError</a></td>
+</tr>
+<tr>
+<td>404</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">Not Found</a></td>
+<td>Resource not found</td>
+<td><a href="#schemanotfounderror">NotFoundError</a></td>
+</tr>
+</tbody>
+</table>
+<h3 id="usersapi--getuserfeatures-responseschema">Response Schema</h3>
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
 basicAuth & bearerAuth & queryAuth
@@ -8116,7 +8361,7 @@ curl -X GET http://127.0.0.1:5252/catalogs/* \
 <td>Filter on catalog id and description</td>
 </tr>
 <tr>
-<td>_nocount</td>
+<td>_countCatalogs</td>
 <td>query</td>
 <td>boolean</td>
 <td>false</td>
@@ -8753,7 +8998,7 @@ curl -X GET http://127.0.0.1:5252/children \
         <span class="hljs-attr">"end_datetime"</span>: <span class="hljs-string">"2020-06-21T11:11:28.371000Z"</span>,
         <span class="hljs-attr">"productIdentifier"</span>: <span class="hljs-string">"S2B_MSIL1C_20200621T111039_N0209_R008_T28HCE_20200621T132349"</span>,
         <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
-        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
+        <span class="hljs-attr">"created"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
         <span class="hljs-attr">"resto:catalogs"</span>: [
           <span class="hljs-string">"ocean/SouthAtlanticOcean"</span>,
           <span class="hljs-string">"landcover/water"</span>,
@@ -8955,11 +9200,11 @@ curl -X GET http://127.0.0.1:5252/children \
 <td>The date when the feature metadata was updated (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)</td>
 </tr>
 <tr>
-<td>»»» published</td>
+<td>»»» created</td>
 <td>string</td>
 <td>false</td>
 <td>none</td>
-<td>The date when the feature metadata was published (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)</td>
+<td>The date when the feature metadata was created (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)</td>
 </tr>
 <tr>
 <td>»»» resto:catalogs</td>
@@ -9302,9 +9547,6 @@ curl -X GET http://127.0.0.1:5252/ \
   <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"title"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"description"</span>: <span class="hljs-string">"string"</span>,
-  <span class="hljs-attr">"capabilities"</span>: [
-    <span class="hljs-string">"string"</span>
-  ],
   <span class="hljs-attr">"links"</span>: [
     {
       <span class="hljs-attr">"rel"</span>: <span class="hljs-string">"self"</span>,
@@ -9372,13 +9614,6 @@ curl -X GET http://127.0.0.1:5252/ \
 <td>false</td>
 <td>none</td>
 <td>Server description</td>
-</tr>
-<tr>
-<td>» capabilities</td>
-<td>[string]</td>
-<td>false</td>
-<td>none</td>
-<td>Array of resto-addons list. Used client side to detect resto capabilities</td>
 </tr>
 <tr>
 <td>» links</td>
@@ -9515,7 +9750,7 @@ This operation does not require authentication
   <span class="hljs-attr">"visibility"</span>: [
     <span class="hljs-string">"default"</span>
   ],
-  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"proprietary"</span>,
+  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"other"</span>,
   <span class="hljs-attr">"providers"</span>: [
     {
       <span class="hljs-attr">"name"</span>: <span class="hljs-string">"European Union/ESA/Copernicus"</span>,
@@ -9534,7 +9769,7 @@ This operation does not require authentication
     }
   ],
   <span class="hljs-attr">"summaries"</span>: {
-    <span class="hljs-attr">"eo:bands"</span>: [
+    <span class="hljs-attr">"bands"</span>: [
       {
         <span class="hljs-attr">"name"</span>: <span class="hljs-string">"B1"</span>,
         <span class="hljs-attr">"common_name"</span>: <span class="hljs-string">"coastal"</span>,
@@ -9678,7 +9913,7 @@ This operation does not require authentication
 <td>string</td>
 <td>false</td>
 <td>none</td>
-<td>License for this collection as a SPDX License identifier. Alternatively, use proprietary if the license is not on the SPDX license list or various if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the license link relation type.</td>
+<td>License for this collection as a SPDX License identifier. Alternatively, use other if the license is not on the SPDX license list. In these case link to the license texts SHOULD be added, see the license link relation type.</td>
 </tr>
 <tr>
 <td>links</td>
@@ -9739,7 +9974,7 @@ This operation does not require authentication
     <span class="hljs-string">"sentinel"</span>,
     <span class="hljs-string">"sentinel2"</span>
   ],
-  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"proprietary"</span>,
+  <span class="hljs-attr">"license"</span>: <span class="hljs-string">"other"</span>,
   <span class="hljs-attr">"extent"</span>: {
     <span class="hljs-attr">"spatial"</span>: {
       <span class="hljs-attr">"bbox"</span>: [
@@ -9816,7 +10051,7 @@ This operation does not require authentication
     <span class="hljs-attr">"productType"</span>: [
       <span class="hljs-string">"REFLECTANCE"</span>
     ],
-    <span class="hljs-attr">"eo:bands"</span>: [
+    <span class="hljs-attr">"bands"</span>: [
       {
         <span class="hljs-attr">"name"</span>: <span class="hljs-string">"B1"</span>,
         <span class="hljs-attr">"common_name"</span>: <span class="hljs-string">"coastal"</span>,
@@ -9957,7 +10192,7 @@ This operation does not require authentication
 <td>string</td>
 <td>true</td>
 <td>none</td>
-<td>License for this collection as a SPDX License identifier or expression. Alternatively, use proprietary if the license is not on the SPDX license list or various if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the license link relation type.</td>
+<td>License for this collection as a SPDX License identifier or expression. Alternatively, use other if the license is not on the SPDX license list. In this case, links to the license texts SHOULD be added, see the license link relation type.</td>
 </tr>
 <tr>
 <td>extent</td>
@@ -10032,11 +10267,7 @@ This operation does not require authentication
 </tr>
 <tr>
 <td>license</td>
-<td>proprietary</td>
-</tr>
-<tr>
-<td>license</td>
-<td>various</td>
+<td>other</td>
 </tr>
 <tr>
 <td>license</td>
@@ -10211,7 +10442,7 @@ This operation does not require authentication
     <span class="hljs-attr">"end_datetime"</span>: <span class="hljs-string">"2020-06-21T11:11:28.371000Z"</span>,
     <span class="hljs-attr">"productIdentifier"</span>: <span class="hljs-string">"S2B_MSIL1C_20200621T111039_N0209_R008_T28HCE_20200621T132349"</span>,
     <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
+    <span class="hljs-attr">"created"</span>: <span class="hljs-string">"2018-09-13T12:52:25.971969Z"</span>,
     <span class="hljs-attr">"resto:catalogs"</span>: [
       <span class="hljs-string">"ocean/SouthAtlanticOcean"</span>,
       <span class="hljs-string">"landcover/water"</span>,
@@ -10358,11 +10589,11 @@ This operation does not require authentication
 <td>The date when the feature metadata was updated (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)</td>
 </tr>
 <tr>
-<td>» published</td>
+<td>» created</td>
 <td>string</td>
 <td>false</td>
 <td>none</td>
-<td>The date when the feature metadata was published (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)</td>
+<td>The date when the feature metadata was created (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)</td>
 </tr>
 <tr>
 <td>» resto:catalogs</td>
@@ -11463,7 +11694,7 @@ This operation does not require authentication
   <span class="hljs-attr">"roles"</span>: [
     <span class="hljs-string">"data"</span>
   ],
-  <span class="hljs-attr">"eo:bands"</span>: [
+  <span class="hljs-attr">"bands"</span>: [
     <span class="hljs-number">0</span>
   ]
 }

--- a/docs/api/resto-api.json
+++ b/docs/api/resto-api.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Welcome to resto",
         "description": "A metadata catalog and search engine for geospatialized data",
-        "version": "9.3.0"
+        "version": "9.6.2"
     },
     "servers": [
         {
@@ -1047,9 +1047,9 @@
                         }
                     },
                     {
-                        "name": "published",
+                        "name": "created",
                         "in": "query",
-                        "description": "Returns products with metadata publication date greater or equal than *published* - OpenSearch {dc:date}",
+                        "description": "Returns products with metadata publication date greater or equal than *created* - OpenSearch {dc:date}",
                         "required": false,
                         "style": "form",
                         "schema": {
@@ -1089,7 +1089,7 @@
                         }
                     },
                     {
-                        "name": "sort",
+                        "name": "sortby",
                         "in": "query",
                         "description": "Sort results by property *startDate* or *created* (default *startDate*). Sorting order is DESCENDING (ASCENDING if property is prefixed by minus sign)",
                         "required": false,
@@ -2693,7 +2693,7 @@
                         }
                     },
                     {
-                        "name": "_nocount",
+                        "name": "_countCatalogs",
                         "in": "query",
                         "description": "Set to 1 to not count number of items below catalogs. Speed up *a lot* the query so should be used when using this for suggest (see rocket catalog search for instance)",
                         "schema": {
@@ -3318,7 +3318,7 @@
                         }
                     },
                     {
-                        "name": "sort",
+                        "name": "sortby",
                         "in": "query",
                         "description": "Sort results by property *startDate* or *created* (default *startDate*). Sorting order is DESCENDING (ASCENDING if property is prefixed by minus sign)",
                         "required": false,
@@ -3665,13 +3665,6 @@
                                         "description": {
                                             "description": "Server description",
                                             "type": "string"
-                                        },
-                                        "capabilities": {
-                                            "description": "Array of resto-addons list. Used client side to detect resto capabilities",
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
                                         },
                                         "links": {
                                             "description": "Landing page conforms to OGC API Feature\n(see https://github.com/opengeospatial/ogcapi-features/blob/master/core/standard/17-069.adoc)",
@@ -4197,6 +4190,177 @@
                     }
                 ]
             }
+        },
+        "/users/{username}/catalogs": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get user's catalogs",
+                "operationId": "UsersAPI::getUserCatalogs",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "User name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User catalogs",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthorizedError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": [],
+                        "bearerAuth": [],
+                        "queryAuth": []
+                    }
+                ]
+            }
+        },
+        "/users/{username}/collections": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get user's collections",
+                "operationId": "UsersAPI::getUserCollections",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "User name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User collections",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthorizedError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": [],
+                        "bearerAuth": [],
+                        "queryAuth": []
+                    }
+                ]
+            }
+        },
+        "/users/{username}/features": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Get user's features",
+                "operationId": "UsersAPI::getUserFeatures",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "path",
+                        "description": "User name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User features",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthorizedError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "basicAuth": [],
+                        "bearerAuth": [],
+                        "queryAuth": []
+                    }
+                ]
+            }
         }
     },
     "components": {
@@ -4238,7 +4402,7 @@
                         "type": "string"
                     },
                     "license": {
-                        "description": "License for this collection as a SPDX License identifier. Alternatively, use proprietary if the license is not on the SPDX license list or various if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the license link relation type.",
+                        "description": "License for this collection as a SPDX License identifier. Alternatively, use other if the license is not on the SPDX license list. In these case link to the license texts SHOULD be added, see the license link relation type.",
                         "type": "string"
                     },
                     "links": {
@@ -4429,11 +4593,10 @@
                         }
                     },
                     "license": {
-                        "description": "License for this collection as a SPDX License identifier or expression. Alternatively, use proprietary if the license is not on the SPDX license list or various if multiple licenses apply. In these two cases links to the license texts SHOULD be added, see the license link relation type.",
+                        "description": "License for this collection as a SPDX License identifier or expression. Alternatively, use other if the license is not on the SPDX license list. In this case, links to the license texts SHOULD be added, see the license link relation type.",
                         "type": "string",
                         "enum": [
-                            "proprietary",
-                            "various",
+                            "other",
                             "<license id>"
                         ]
                     },
@@ -4822,8 +4985,8 @@
                                 "description": "The date when the feature metadata was updated (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)",
                                 "type": "string"
                             },
-                            "published": {
-                                "description": "The date when the feature metadata was published (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)",
+                            "created": {
+                                "description": "The date when the feature metadata was created (ISO 8601 - YYYY-MM-DD-THH:MM:SSZ)",
                                 "type": "string"
                             },
                             "resto:catalogs": {
@@ -4928,7 +5091,7 @@
                         "end_datetime": "2020-06-21T11:11:28.371000Z",
                         "productIdentifier": "S2B_MSIL1C_20200621T111039_N0209_R008_T28HCE_20200621T132349",
                         "updated": "2018-09-13T12:52:25.971969Z",
-                        "published": "2018-09-13T12:52:25.971969Z",
+                        "created": "2018-09-13T12:52:25.971969Z",
                         "resto:catalogs": [
                             "ocean/SouthAtlanticOcean",
                             "landcover/water",

--- a/examples/catalogs/collectionsCatalog.json
+++ b/examples/catalogs/collectionsCatalog.json
@@ -1,0 +1,8 @@
+{
+    "id": "collections",
+    "title": "A first level catalogs called collections is not allowed",
+    "type": "Catalog",
+    "description":"Will never be created",
+    "stac_version":"1.0.0",
+    "links":[]
+}

--- a/examples/catalogs/externalCatalog.json
+++ b/examples/catalogs/externalCatalog.json
@@ -1,0 +1,16 @@
+{
+    "id": "CDSE",
+    "title": "This is an external catalog",
+    "type": "Catalog",
+    "description":"When setting root link to an external url, resto proxies the request to the external catalog.",
+    "stac_version":"1.0.0",
+    "links":[
+        {
+            "rel": "root",
+            "href": "https://stac.dataspace.copernicus.eu/v1/",
+            "type": "application/json",
+            "title": "Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue",
+            "description": "Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue"
+        }
+    ]
+}

--- a/examples/catalogs/janeDoeCatalog.json
+++ b/examples/catalogs/janeDoeCatalog.json
@@ -1,0 +1,7 @@
+{
+    "id": "JaneDoeCatalog",
+    "title": "Jane Doe Catalog",
+    "type": "Catalog",
+    "description":"This is a simple catalog - it is private by default",
+    "stac_version":"1.1.0"
+}

--- a/examples/catalogs/janeDoeCatalog_update.json
+++ b/examples/catalogs/janeDoeCatalog_update.json
@@ -1,0 +1,5 @@
+{
+    "visibility":[
+        "My first group"
+    ]
+}

--- a/examples/catalogs/usersCatalog.json
+++ b/examples/catalogs/usersCatalog.json
@@ -1,0 +1,8 @@
+{
+    "id": "users",
+    "title": "A first level catalogs called users is not allowed",
+    "type": "Catalog",
+    "description":"Will never be created",
+    "stac_version":"1.0.0",
+    "links":[]
+}

--- a/examples/items/johnDoeItem.json
+++ b/examples/items/johnDoeItem.json
@@ -3,7 +3,10 @@
     "type": "Feature",
     "properties": {
         "datetime": "2024-06-21T16:27:00Z",
-        "description": "This is an item belonging to JohnDoeCollection"
+        "description": "This is an item belonging to JohnDoeCollection",
+        "visibility": [
+            "default"
+        ]
     },
     "geometry": {
         "coordinates": [

--- a/examples/items/johnDoeItem_visibility.json
+++ b/examples/items/johnDoeItem_visibility.json
@@ -1,5 +1,5 @@
 {
     "visibility":[
-        "default"
+        "My first group"
     ]
 }

--- a/resto-database-model/03_resto_target_model.sql
+++ b/resto-database-model/03_resto_target_model.sql
@@ -362,7 +362,10 @@ CREATE TABLE IF NOT EXISTS __DATABASE_TARGET_SCHEMA__.catalog (
     rtype               TEXT,
 
     -- Free object to store info
-    properties          JSON
+    properties          JSON,
+
+    -- [STAC PROXY] This catalog is a proxy to a STAC catalog
+    stac_url            TEXT
 
 );
 

--- a/resto-database-model/postInstall/01_inserts.sql
+++ b/resto-database-model/postInstall/01_inserts.sql
@@ -5,5 +5,5 @@ INSERT INTO __DATABASE_COMMON_SCHEMA__.group (id, name, description, created) VA
 
 -- [TABLE __DATABASE_COMMON_SCHEMA__.right] admin rights
 INSERT INTO __DATABASE_COMMON_SCHEMA__.right (groupid, rights)
-VALUES (0, '{"createCollection":true, "deleteAnyCollection": true, "updateAnyCollection": true,"createCatalog":true, "deleteAnyCatalog": true, "updateAnyCatalog": true, "createAnyFeature": true, "deleteAnyFeature": true, "updateAnyFeature": true, "downloadFeature": true}') 
-ON CONFLICT(groupid) DO UPDATE SET rights='{"createCollection":true, "deleteAnyCollection": true, "updateAnyCollection": true,"createCatalog":true, "deleteAnyCatalog": true, "updateAnyCatalog": true, "createAnyFeature": true, "deleteAnyFeature": true, "updateAnyFeature": true, "downloadFeature": true}';
+VALUES (0, '{"createCollection":true, "deleteAnyCollection": true, "updateAnyCollection": true,"createCatalog":true, "createAnyCatalog":true, "deleteAnyCatalog": true, "updateAnyCatalog": true, "createAnyFeature": true, "deleteAnyFeature": true, "updateAnyFeature": true, "downloadFeature": true}') 
+ON CONFLICT(groupid) DO UPDATE SET rights='{"createCollection":true, "deleteAnyCollection": true, "updateAnyCollection": true,"createCatalog":true, "createAnyCatalog":true, "deleteAnyCatalog": true, "updateAnyCatalog": true, "createAnyFeature": true, "deleteAnyFeature": true, "updateAnyFeature": true, "downloadFeature": true}';


### PR DESCRIPTION
This is a major release with basically two main functionalities:
* Support for proxy of external catalog i.e. you can now add an external STAC endpoint to a catalog by adding  a "rel=root" link pointing to this endpoint. resto will then act as a broker to this catalog without the need of harvesting it
* Update of rights management. Any user can POST/PUT/DELETE under its private /catalogs/users/{username} catalog. Any other location is read only by default