### PR TITLE
Fixed when posting catalogs under with visibility not as an array client receives 500 with no error message

### DIFF
--- a/app/resto/core/dbfunctions/GeneralFunctions.php
+++ b/app/resto/core/dbfunctions/GeneralFunctions.php
@@ -192,9 +192,9 @@ class GeneralFunctions
      */
     public function visibilityNamesToIds($visibility)
     {
-       
-        if ( empty($visibility) ) {
-            throw new Exception();
+
+        if ( empty($visibility) || !is_array($visibility) ) {
+            throw new Exception('Visibility must be a non-empty array of group names', 400);
         }
 
         $ids = array();


### PR DESCRIPTION
When posting without validating visibility to an array of groups the client returned an uncaught error 500 with no error message.